### PR TITLE
Enable Hackage friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,3 +10,4 @@ extra-deps: []
 flags: {}
 # Extra package databases containing global packages
 extra-package-dbs: []
+pvp-bounds: both


### PR DESCRIPTION
This will help hs-web3 from bitrotting on Hackage, as well as  address #1 as a side-effect as well 

See also https://docs.haskellstack.org/en/stable/yaml_configuration/?highlight=pvp-bounds#pvp-bounds