### PR TITLE
use entire deserialized `Change` object

### DIFF
--- a/src/Network/Ethereum/Web3/Contract.hs
+++ b/src/Network/Ethereum/Web3/Contract.hs
@@ -63,7 +63,7 @@ data EventAction = ContinueEvent
 -- | Contract event listener
 class ABIEncoding a => Event a where
     -- | Event filter structure used by low-level subscription methods
-    eventFilter :: Change a -> Address -> Filter
+    eventFilter :: a -> Address -> Filter
 
     -- | Start an event listener for given contract 'Address' and callback
     event :: Provider p
@@ -82,7 +82,7 @@ _event :: (Provider p, Event a)
 _event a f = do
     fid <- let ftyp = snd $ let x = undefined :: Event a => Change a
                             in  (f x, x)
-           in  eth_newFilter (eventFilter ftyp a)
+           in  eth_newFilter (eventFilter (changeData ftyp) a)
 
     forkWeb3 $
         let loop = do liftIO (threadDelay 1000000)

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -65,7 +65,7 @@ $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 6 }) ''Filter)
 
 -- | Event filder ident
-newtype FilterId = FilterId Int
+newtype FilterId = FilterId Integer
   deriving (Show, Eq, Ord)
 
 instance FromJSON FilterId where


### PR DESCRIPTION
It is currently the case that you deserialize the `Change` object with a data field of `Text` type, then directly parse that data field using `parseData`, and finally discard the rest of the object. It's useful to expose the entire `Change` object-- for example I would like to store all of the event metadata in an auxiliary data store, and one can imagine wanting to decide to continue polling the event based on block number or something like that. This pull request is a small breaking change that would allow that.