### PR TITLE
adding a few additional RPC methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
     - env: STACK=YES
   allow_failures:
+    - env: GHCVER=8.0.1 CABALVER=1.24
+    - env: GHCVER=8.0.2 CABALVER=1.24
     - env: GHCVER=head CABALVER=head
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
     - env: STACK=YES
   allow_failures:
-    - env: GHCVER=8.0.1 CABALVER=1.24
-    - env: GHCVER=8.0.2 CABALVER=1.24
     - env: GHCVER=head CABALVER=head
 
 before_cache:

--- a/src/Network/Ethereum/Web3/Address.hs
+++ b/src/Network/Ethereum/Web3/Address.hs
@@ -52,7 +52,7 @@ fromText :: Text -> Either String Address
 fromText = fmap (Address . fst) . R.hexadecimal <=< check
   where check t | T.take 2 t == "0x" = check (T.drop 2 t)
                 | otherwise = do if T.length t == 40 then pure () else lengthError
-                                 if T.all (C.isHexDigit) t then pure () else invalidCharError
+                                 if T.all C.isHexDigit t then pure () else invalidCharError
                                  pure t
         lengthError = Left "Invalid Address: text length not equal to 20"
         invalidCharError = Left "Invalid Address: contains non-hex character"

--- a/src/Network/Ethereum/Web3/Address.hs
+++ b/src/Network/Ethereum/Web3/Address.hs
@@ -17,6 +17,7 @@ module Network.Ethereum.Web3.Address (
   ) where
 
 import Data.Aeson (FromJSON(..), ToJSON(..), Value(..))
+import qualified Data.Char as C
 import Data.Text.Lazy.Builder.Int as B (hexadecimal)
 import Data.Text.Lazy.Builder (toLazyText)
 import Data.Text.Read as R (hexadecimal)
@@ -50,10 +51,11 @@ instance ToJSON Address where
 fromText :: Text -> Either String Address
 fromText = fmap (Address . fst) . R.hexadecimal <=< check
   where check t | T.take 2 t == "0x" = check (T.drop 2 t)
-                | otherwise = if T.length t == 40 && T.all (`elem` valid) t
-                              then Right t
-                              else Left "This is not seems like address."
-        valid = ['0'..'9'] ++ ['a'..'f'] ++ ['A'..'F']
+                | otherwise = do if T.length t == 40 then pure () else lengthError
+                                 if T.all (C.isHexDigit) t then pure () else invalidCharError
+                                 pure t
+        lengthError = Left "Invalid Address: text length not equal to 20"
+        invalidCharError = Left "Invalid Address: contains non-hex character"
 
 -- | Render 'Address' to text string
 toText :: Address -> Text

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -135,7 +135,7 @@ eth_call = remote "eth_call"
 
 -- | Makes a call or transaction, which won't be added to the blockchain and
 -- returns the used gas, which can be used for estimating the used gas.
-eth_estimateGas :: Provider a => Call -> CallMode -> Web3 a Text
+eth_estimateGas :: Provider a => Call -> Web3 a Text
 eth_estimateGas = remote "eth_estimateGas"
 
 -- | Returns information about a block by hash.
@@ -151,13 +151,18 @@ eth_getTransactionByHash :: Provider a => Text -> Web3 a (Maybe Transaction)
 eth_getTransactionByHash = remote "eth_getTransactionByHash"
 
 -- | Returns information about a transaction by block hash and transaction index position.
-eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text ->  Web3 a (Maybe Transaction)
+eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text -> Web3 a (Maybe Transaction)
 eth_getTransactionByBlockHashAndIndex = remote "eth_getTransactionByBlockHashAndIndex"
 
 -- | Returns information about a transaction by block number and transaction
 -- index position.
-eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text ->  Web3 a (Maybe Transaction)
+eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text -> Web3 a (Maybe Transaction)
 eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumberAndIndex"
+
+-- | Returns the receipt of a transaction by transaction hash.
+-- TODO must create new type, TxReceipt
+-- eth_getTransactionReceipt :: Provider a => Text -> Web3 a TxReceipt
+-- eth_getTransactionReceipt = remote "eth_getTransactionReceipt"
 
 -- | Returns a list of addresses owned by client.
 eth_accounts :: Provider a => Web3 a [Address]

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -53,6 +53,9 @@ eth_mining = remote "eth_mining"
 eth_hashrate :: Provider a => Web3 a Text
 eth_hashrate = remote "eth_hashrate"
 
+eth_getTransactionCount :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getTransactionCount = remote "eth_getTransactionCount"
+
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
 eth_getBalance = remote "eth_getBalance"
@@ -135,6 +138,7 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_coinbase #-}
 {-# INLINE eth_mining #-}
 {-# INLINE eth_hashrate #-}
+{-# INLINE eth_getTransactionCount #-}
 {-# INLINE eth_getBalance #-}
 {-# INLINE eth_newFilter #-}
 {-# INLINE eth_getFilterChanges #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -133,6 +133,32 @@ eth_getLogs = remote "eth_getLogs"
 eth_call :: Provider a => Call -> CallMode -> Web3 a Text
 eth_call = remote "eth_call"
 
+-- | Makes a call or transaction, which won't be added to the blockchain and
+-- returns the used gas, which can be used for estimating the used gas.
+eth_estimateGas :: Provider a => Call -> CallMode -> Web3 a Text
+eth_estimateGas = remote "eth_estimateGas"
+
+-- | Returns information about a block by hash.
+eth_getBlockByHash :: Provider a => Text -> Web3 a Block
+eth_getBlockByHash = flip (remote "eth_getBlockByHash") True
+
+-- | Returns information about a block by block number.
+eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
+eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
+
+-- | Returns the information about a transaction requested by transaction hash.
+eth_getTransactionByHash :: Provider a => Text -> Web3 a Transaction
+eth_getTransactionByHash = remote "eth_getBlockByHash"
+
+-- | Returns information about a transaction by block hash and transaction index position.
+eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text ->  Web3 a Transaction
+eth_getTransactionByBlockHashAndIndex = remote "eth_getTransactionByBlockHashAndIndex"
+
+-- | Returns information about a transaction by block number and transaction
+-- index position.
+eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text ->  Web3 a Transaction
+eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumberAndIndex"
+
 -- | Returns a list of addresses owned by client.
 eth_accounts :: Provider a => Web3 a [Address]
 eth_accounts = remote "eth_accounts"
@@ -144,14 +170,6 @@ eth_newBlockFilter = remote "eth_newBlockFilter"
 -- occurred since last poll.
 eth_getBlockFilterChanges :: Provider a => Text -> Web3 a [Text]
 eth_getBlockFilterChanges = remote "eth_getFilterChanges"
-
--- | Returns information about a block by hash.
-eth_getBlockByHash :: Provider a => Text -> Web3 a Block
-eth_getBlockByHash = flip (remote "eth_getBlockByHash") True
-
--- | Returns information about a block by block number.
-eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
-eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 
 -- | Returns the number of most recent block.
 eth_blockNumber :: Provider a => Web3 a Text
@@ -181,6 +199,10 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_uninstallFilter #-}
 {-# INLINE eth_getLogs #-}
 {-# INLINE eth_call #-}
+{-# INLINE eth_estimateGas #-}
+{-# INLINE eth_getTransactionByHash #-}
+{-# INLINE eth_getTransactionByBlockHashAndIndex #-}
+{-# INLINE eth_getTransactionByBlockNumberAndIndex #-}
 {-# INLINE eth_sign #-}
 {-# INLINE eth_getCode #-}
 {-# INLINE eth_sendTransaction #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -27,6 +27,21 @@ web3_sha3 :: Provider a => Text -> Web3 a Text
 {-# INLINE web3_sha3 #-}
 web3_sha3 = remote "web3_sha3"
 
+-- | Returns the client coinbase address.
+eth_coinbase :: Provider a => Web3 a Address
+{-# INLINE eth_coinbase #-}
+eth_coinbase = remote "eth_coinbase"
+
+-- | Returns true if client is actively mining new blocks.
+eth_mining :: Provider a => Web3 a Bool
+{-# INLINE eth_mining #-}
+eth_mining = remote "eth_mining"
+
+-- | Returns the number of hashes per second that the node is mining with.
+eth_hashrate :: Provider a => Web3 a Text
+{-# INLINE eth_hashrate #-}
+eth_hashrate = remote "eth_hashrate"
+
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
 {-# INLINE eth_getBalance #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -99,6 +99,11 @@ eth_sign = remote "eth_sign"
 eth_sendTransaction :: Provider a => Call -> Web3 a Text
 eth_sendTransaction = remote "eth_sendTransaction"
 
+-- | Creates new message call transaction or a contract creation for signed
+-- transactions.
+eth_sendRawTransaction :: Provider a => Text -> Web3 a Text
+eth_sendRawTransaction = remote "eth_sendRawTransaction"
+
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
 eth_getBalance = remote "eth_getBalance"
@@ -179,6 +184,7 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_sign #-}
 {-# INLINE eth_getCode #-}
 {-# INLINE eth_sendTransaction #-}
+{-# INLINE eth_sendRawTransaction #-}
 {-# INLINE eth_accounts #-}
 {-# INLINE eth_newBlockFilter #-}
 {-# INLINE eth_getBlockFilterChanges #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -58,11 +58,11 @@ eth_hashrate :: Provider a => Web3 a Text
 eth_hashrate = remote "eth_hashrate"
 
 -- | Returns the value from a storage position at a given address.
-eth_getStorageAt :: Provider a => Address -> Text -> CallMode -> Web3 a Text
+eth_getStorageAt :: Provider a => Address -> Text -> DefaultBlock -> Web3 a Text
 eth_getStorageAt = remote "eth_getStorageAt"
 
 -- | Returns the number of transactions sent from an address.
-eth_getTransactionCount :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getTransactionCount :: Provider a => Address -> DefaultBlock -> Web3 a Text
 eth_getTransactionCount = remote "eth_getTransactionCount"
 
 -- | Returns the number of transactions in a block from a block matching the given block hash.
@@ -86,7 +86,7 @@ eth_getUncleCountByBlockNumber :: Provider a => Text -> Web3 a Text
 eth_getUncleCountByBlockNumber = remote "eth_getUncleCountByBlockNumber"
 
 -- | Returns code at a given address.
-eth_getCode :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getCode :: Provider a => Address -> DefaultBlock -> Web3 a Text
 eth_getCode = remote "eth_getCode"
 
 -- | Returns an Ethereum specific signature with:
@@ -105,7 +105,7 @@ eth_sendRawTransaction :: Provider a => Text -> Web3 a Text
 eth_sendRawTransaction = remote "eth_sendRawTransaction"
 
 -- | Returns the balance of the account of given address.
-eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getBalance :: Provider a => Address -> DefaultBlock -> Web3 a Text
 eth_getBalance = remote "eth_getBalance"
 
 -- | Creates a filter object, based on filter options, to notify when the
@@ -130,7 +130,7 @@ eth_getLogs = remote "eth_getLogs"
 
 -- | Executes a new message call immediately without creating a
 -- transaction on the block chain.
-eth_call :: Provider a => Call -> CallMode -> Web3 a Text
+eth_call :: Provider a => Call -> DefaultBlock -> Web3 a Text
 eth_call = remote "eth_call"
 
 -- | Makes a call or transaction, which won't be added to the blockchain and
@@ -156,7 +156,7 @@ eth_getTransactionByBlockHashAndIndex = remote "eth_getTransactionByBlockHashAnd
 
 -- | Returns information about a transaction by block number and transaction
 -- index position.
-eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text -> Web3 a (Maybe Transaction)
+eth_getTransactionByBlockNumberAndIndex :: Provider a => DefaultBlock -> Text -> Web3 a (Maybe Transaction)
 eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumberAndIndex"
 
 -- | Returns the receipt of a transaction by transaction hash.

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -62,6 +62,10 @@ eth_call :: Provider a => Call -> CallMode -> Web3 a Text
 {-# INLINE eth_call #-}
 eth_call = remote "eth_call"
 
+eth_sign :: Provider a => Address -> Text -> Web3 a Text
+{-# INLINE eth_sign #-}
+eth_sign = remote "eth_sign"
+
 -- | Creates new message call transaction or a contract creation,
 -- if the data field contains code.
 eth_sendTransaction :: Provider a => Call -> Web3 a Text

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -27,6 +27,21 @@ web3_sha3 :: Provider a => Text -> Web3 a Text
 {-# INLINE web3_sha3 #-}
 web3_sha3 = remote "web3_sha3"
 
+-- | Returns the current network id.
+net_version :: Provider a => Web3 a Text
+{-# INLINE net_version #-}
+net_version = remote "net_version"
+
+-- | Returns true if client is actively listening for network connections.
+net_listening :: Provider a => Web3 a Bool
+{-# INLINE net_listening #-}
+net_listening = remote "net_listening"
+
+-- | Returns number of peers currently connected to the client.
+net_peerCount :: Provider a => Web3 a Text
+{-# INLINE net_peerCount #-}
+net_peerCount = remote "net_peerCount"
+
 -- | Returns the client coinbase address.
 eth_coinbase :: Provider a => Web3 a Address
 {-# INLINE eth_coinbase #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -184,6 +184,26 @@ eth_blockNumber = remote "eth_blockNumber"
 eth_gasPrice :: Provider a => Web3 a Text
 eth_gasPrice = remote "eth_gasPrice"
 
+-- | Returns the hash of the current block, the seedHash, and the boundary
+-- condition to be met ("target").
+eth_getWork :: Provider a => Web3 a [Text]
+eth_getWork = remote "eth_getWork"
+
+-- | Used for submitting a proof-of-work solution.
+-- Parameters:
+-- 1. DATA, 8 Bytes - The nonce found (64 bits)
+-- 2. DATA, 32 Bytes - The header's pow-hash (256 bits)
+-- 3. DATA, 32 Bytes - The mix digest (256 bits)
+eth_submitWork :: Provider a => Text -> Text -> Text -> Web3 a Bool
+eth_submitWork = remote "eth_submitWork"
+
+-- | Used for submitting mining hashrate.
+-- Parameters:
+-- 1. Hashrate, a hexadecimal string representation (32 bytes) of the hash rate
+-- 2. ID, String - A random hexadecimal(32 bytes) ID identifying the client
+eth_submitHashrate :: Provider a => Text -> Text -> Web3 a Bool
+eth_submitHashrate = remote "eth_submitHashrate"
+
 {-# INLINE web3_clientVersion #-}
 {-# INLINE web3_sha3 #-}
 {-# INLINE net_version #-}
@@ -220,3 +240,6 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_blockNumber #-}
 {-# INLINE eth_getBlockTransactionCountByNumber #-}
 {-# INLINE eth_gasPrice #-}
+{-# INLINE eth_getWork #-}
+{-# INLINE eth_submitWork #-}
+{-# INLINE eth_submitHashrate #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -42,6 +42,11 @@ net_peerCount :: Provider a => Web3 a Text
 {-# INLINE net_peerCount #-}
 net_peerCount = remote "net_peerCount"
 
+-- | Returns the current ethereum protocol version.
+eth_protocolVersion :: Provider a => Web3 a Text
+{-# INLINE eth_protocolVersion #-}
+eth_protocolVersion = remote "eth_protocolVersion"
+
 -- | Returns the client coinbase address.
 eth_coinbase :: Provider a => Web3 a Address
 {-# INLINE eth_coinbase #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -19,26 +19,32 @@ import Data.Text (Text)
 
 -- | Returns current node version string.
 web3_clientVersion :: Provider a => Web3 a Text
+{-# INLINE web3_clientVersion #-}
 web3_clientVersion = remote "web3_clientVersion"
 
 -- | Returns Keccak-256 (not the standardized SHA3-256) of the given data.
 web3_sha3 :: Provider a => Text -> Web3 a Text
+{-# INLINE web3_sha3 #-}
 web3_sha3 = remote "web3_sha3"
 
 -- | Returns the current network id.
 net_version :: Provider a => Web3 a Text
+{-# INLINE net_version #-}
 net_version = remote "net_version"
 
 -- | Returns true if client is actively listening for network connections.
 net_listening :: Provider a => Web3 a Bool
+{-# INLINE net_listening #-}
 net_listening = remote "net_listening"
 
 -- | Returns number of peers currently connected to the client.
 net_peerCount :: Provider a => Web3 a Text
+{-# INLINE net_peerCount #-}
 net_peerCount = remote "net_peerCount"
 
 -- | Returns the current ethereum protocol version.
 eth_protocolVersion :: Provider a => Web3 a Text
+{-# INLINE eth_protocolVersion #-}
 eth_protocolVersion = remote "eth_protocolVersion"
 
 -- TODO The return type of this function requires a new type to be created
@@ -47,116 +53,140 @@ eth_protocolVersion = remote "eth_protocolVersion"
 
 -- | Returns the client coinbase address.
 eth_coinbase :: Provider a => Web3 a Address
+{-# INLINE eth_coinbase #-}
 eth_coinbase = remote "eth_coinbase"
 
 -- | Returns true if client is actively mining new blocks.
 eth_mining :: Provider a => Web3 a Bool
+{-# INLINE eth_mining #-}
 eth_mining = remote "eth_mining"
 
 -- | Returns the number of hashes per second that the node is mining with.
 eth_hashrate :: Provider a => Web3 a Text
+{-# INLINE eth_hashrate #-}
 eth_hashrate = remote "eth_hashrate"
 
 -- | Returns the value from a storage position at a given address.
 eth_getStorageAt :: Provider a => Address -> Text -> DefaultBlock -> Web3 a Text
+{-# INLINE eth_getStorageAt #-}
 eth_getStorageAt = remote "eth_getStorageAt"
 
 -- | Returns the number of transactions sent from an address.
 eth_getTransactionCount :: Provider a => Address -> DefaultBlock -> Web3 a Text
+{-# INLINE eth_getTransactionCount #-}
 eth_getTransactionCount = remote "eth_getTransactionCount"
 
 -- | Returns the number of transactions in a block from a block matching the given block hash.
 eth_getBlockTransactionCountByHash :: Provider a => Text -> Web3 a Text
+{-# INLINE eth_getBlockTransactionCountByHash #-}
 eth_getBlockTransactionCountByHash = remote "eth_getBlockTransactionCountByHash"
 
 -- | Returns the number of transactions in a block matching the
 -- given block number.
 eth_getBlockTransactionCountByNumber :: Provider a => Text -> Web3 a Text
-eth_getBlockTransactionCountByNumber =
-    remote "eth_getBlockTransactionCountByNumber"
+{-# INLINE eth_getBlockTransactionCountByNumber #-}
+eth_getBlockTransactionCountByNumber = remote "eth_getBlockTransactionCountByNumber"
 
 -- | Returns the number of uncles in a block from a block matching the given
 -- block hash.
 eth_getUncleCountByBlockHash :: Provider a => Text -> Web3 a Text
+{-# INLINE eth_getUncleCountByBlockHash #-}
 eth_getUncleCountByBlockHash = remote "eth_getUncleCountByBlockHash"
 
 -- | Returns the number of uncles in a block from a block matching the given
 -- block number.
 eth_getUncleCountByBlockNumber :: Provider a => Text -> Web3 a Text
+{-# INLINE eth_getUncleCountByBlockNumber #-}
 eth_getUncleCountByBlockNumber = remote "eth_getUncleCountByBlockNumber"
 
 -- | Returns code at a given address.
 eth_getCode :: Provider a => Address -> DefaultBlock -> Web3 a Text
+{-# INLINE eth_getCode #-}
 eth_getCode = remote "eth_getCode"
 
 -- | Returns an Ethereum specific signature with:
 -- sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))).
 eth_sign :: Provider a => Address -> Text -> Web3 a Text
+{-# INLINE eth_sign #-}
 eth_sign = remote "eth_sign"
 
 -- | Creates new message call transaction or a contract creation,
 -- if the data field contains code.
 eth_sendTransaction :: Provider a => Call -> Web3 a Text
+{-# INLINE eth_sendTransaction #-}
 eth_sendTransaction = remote "eth_sendTransaction"
 
 -- | Creates new message call transaction or a contract creation for signed
 -- transactions.
 eth_sendRawTransaction :: Provider a => Text -> Web3 a Text
+{-# INLINE eth_sendRawTransaction #-}
 eth_sendRawTransaction = remote "eth_sendRawTransaction"
 
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> DefaultBlock -> Web3 a Text
+{-# INLINE eth_getBalance #-}
 eth_getBalance = remote "eth_getBalance"
 
 -- | Creates a filter object, based on filter options, to notify when the
 -- state changes (logs). To check if the state has changed, call
 -- 'getFilterChanges'.
 eth_newFilter :: Provider a => Filter -> Web3 a FilterId
+{-# INLINE eth_newFilter #-}
 eth_newFilter = remote "eth_newFilter"
 
 -- | Polling method for a filter, which returns an array of logs which
 -- occurred since last poll.
 eth_getFilterChanges :: Provider a => FilterId -> Web3 a [Change]
+{-# INLINE eth_getFilterChanges #-}
 eth_getFilterChanges = remote "eth_getFilterChanges"
 
 -- | Uninstalls a filter with given id.
 -- Should always be called when watch is no longer needed.
 eth_uninstallFilter :: Provider a => FilterId -> Web3 a Bool
+{-# INLINE eth_uninstallFilter #-}
 eth_uninstallFilter = remote "eth_uninstallFilter"
 
 -- | Returns an array of all logs matching a given filter object.
 eth_getLogs :: Provider a => Filter -> Web3 a [Change]
+{-# INLINE eth_getLogs #-}
 eth_getLogs = remote "eth_getLogs"
 
 -- | Executes a new message call immediately without creating a
 -- transaction on the block chain.
 eth_call :: Provider a => Call -> DefaultBlock -> Web3 a Text
+{-# INLINE eth_call #-}
 eth_call = remote "eth_call"
 
 -- | Makes a call or transaction, which won't be added to the blockchain and
 -- returns the used gas, which can be used for estimating the used gas.
 eth_estimateGas :: Provider a => Call -> Web3 a Text
+{-# INLINE eth_estimateGas #-}
 eth_estimateGas = remote "eth_estimateGas"
 
 -- | Returns information about a block by hash.
 eth_getBlockByHash :: Provider a => Text -> Web3 a Block
+{-# INLINE eth_getBlockByHash #-}
 eth_getBlockByHash = flip (remote "eth_getBlockByHash") True
 
 -- | Returns information about a block by block number.
 eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
+{-# INLINE eth_getBlockByNumber #-}
 eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 
 -- | Returns the information about a transaction requested by transaction hash.
 eth_getTransactionByHash :: Provider a => Text -> Web3 a (Maybe Transaction)
+{-# INLINE eth_getTransactionByHash #-}
 eth_getTransactionByHash = remote "eth_getTransactionByHash"
 
 -- | Returns information about a transaction by block hash and transaction index position.
 eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text -> Web3 a (Maybe Transaction)
+{-# INLINE eth_getTransactionByBlockHashAndIndex #-}
 eth_getTransactionByBlockHashAndIndex = remote "eth_getTransactionByBlockHashAndIndex"
 
 -- | Returns information about a transaction by block number and transaction
 -- index position.
 eth_getTransactionByBlockNumberAndIndex :: Provider a => DefaultBlock -> Text -> Web3 a (Maybe Transaction)
+{-# INLINE eth_getTransactionByBlockNumberAndIndex #-}
 eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumberAndIndex"
 
 -- | Returns the receipt of a transaction by transaction hash.
@@ -166,45 +196,55 @@ eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumbe
 
 -- | Returns a list of addresses owned by client.
 eth_accounts :: Provider a => Web3 a [Address]
+{-# INLINE eth_accounts #-}
 eth_accounts = remote "eth_accounts"
 
 eth_newBlockFilter :: Provider a => Web3 a Text
+{-# INLINE eth_newBlockFilter #-}
 eth_newBlockFilter = remote "eth_newBlockFilter"
 
 -- | Polling method for a block filter, which returns an array of block hashes
 -- occurred since last poll.
 eth_getBlockFilterChanges :: Provider a => Text -> Web3 a [Text]
-eth_getBlockFilterChanges = remote "eth_getFilterChanges"
+{-# INLINE eth_getBlockFilterChanges #-}
+eth_getBlockFilterChanges = remote "eth_getBlockFilterChanges"
 
 -- | Returns the number of most recent block.
 eth_blockNumber :: Provider a => Web3 a Text
+{-# INLINE eth_blockNumber #-}
 eth_blockNumber = remote "eth_blockNumber"
 
 -- | Returns the current price per gas in wei.
 eth_gasPrice :: Provider a => Web3 a Text
+{-# INLINE eth_gasPrice #-}
 eth_gasPrice = remote "eth_gasPrice"
 
 -- | Returns information about a uncle of a block by hash and uncle index
 -- position.
 eth_getUncleByBlockHashAndIndex :: Provider a => Text -> Text -> Web3 a Block
+{-# INLINE eth_getUncleByBlockHashAndIndex #-}
 eth_getUncleByBlockHashAndIndex = remote "eth_getUncleByBlockHashAndIndex"
 
 -- | Returns information about a uncle of a block by number and uncle index
 -- position.
 eth_getUncleByBlockNumberAndIndex :: Provider a => DefaultBlock -> Text -> Web3 a Block
+{-# INLINE eth_getUncleByBlockNumberAndIndex #-}
 eth_getUncleByBlockNumberAndIndex = remote "eth_getUncleByBlockNumberAndIndex"
 
 -- | Creates a filter in the node, to notify when new pending transactions arrive. To check if the state has changed, call eth_getFilterChanges. Returns a FilterId.
 eth_newPendingTransactionFilter :: Provider a => Web3 a Text
+{-# INLINE eth_newPendingTransactionFilter #-}
 eth_newPendingTransactionFilter = remote "eth_newPendingTransactionFilter"
 
 -- | Returns an array of all logs matching filter with given id.
 eth_getFilterLogs :: Provider a => Text -> Web3 a [Change]
+{-# INLINE eth_getFilterLogs #-}
 eth_getFilterLogs = remote "eth_getFilterLogs"
 
 -- | Returns the hash of the current block, the seedHash, and the boundary
 -- condition to be met ("target").
 eth_getWork :: Provider a => Web3 a [Text]
+{-# INLINE eth_getWork #-}
 eth_getWork = remote "eth_getWork"
 
 -- | Used for submitting a proof-of-work solution.
@@ -213,6 +253,7 @@ eth_getWork = remote "eth_getWork"
 -- 2. DATA, 32 Bytes - The header's pow-hash (256 bits)
 -- 3. DATA, 32 Bytes - The mix digest (256 bits)
 eth_submitWork :: Provider a => Text -> Text -> Text -> Web3 a Bool
+{-# INLINE eth_submitWork #-}
 eth_submitWork = remote "eth_submitWork"
 
 -- | Used for submitting mining hashrate.
@@ -220,48 +261,5 @@ eth_submitWork = remote "eth_submitWork"
 -- 1. Hashrate, a hexadecimal string representation (32 bytes) of the hash rate
 -- 2. ID, String - A random hexadecimal(32 bytes) ID identifying the client
 eth_submitHashrate :: Provider a => Text -> Text -> Web3 a Bool
-eth_submitHashrate = remote "eth_submitHashrate"
-
-{-# INLINE web3_clientVersion #-}
-{-# INLINE web3_sha3 #-}
-{-# INLINE net_version #-}
-{-# INLINE net_listening #-}
-{-# INLINE net_peerCount #-}
-{-# INLINE eth_protocolVersion #-}
-{-# INLINE eth_coinbase #-}
-{-# INLINE eth_mining #-}
-{-# INLINE eth_hashrate #-}
-{-# INLINE eth_getStorageAt #-}
-{-# INLINE eth_getTransactionCount #-}
-{-# INLINE eth_getBlockTransactionCountByHash #-}
-{-# INLINE eth_getUncleCountByBlockHash #-}
-{-# INLINE eth_getUncleCountByBlockNumber #-}
-{-# INLINE eth_getBalance #-}
-{-# INLINE eth_newFilter #-}
-{-# INLINE eth_getFilterChanges #-}
-{-# INLINE eth_uninstallFilter #-}
-{-# INLINE eth_getLogs #-}
-{-# INLINE eth_call #-}
-{-# INLINE eth_estimateGas #-}
-{-# INLINE eth_getTransactionByHash #-}
-{-# INLINE eth_getTransactionByBlockHashAndIndex #-}
-{-# INLINE eth_getTransactionByBlockNumberAndIndex #-}
-{-# INLINE eth_sign #-}
-{-# INLINE eth_getCode #-}
-{-# INLINE eth_sendTransaction #-}
-{-# INLINE eth_sendRawTransaction #-}
-{-# INLINE eth_accounts #-}
-{-# INLINE eth_newBlockFilter #-}
-{-# INLINE eth_getBlockFilterChanges #-}
-{-# INLINE eth_getBlockByHash #-}
-{-# INLINE eth_getBlockByNumber #-}
-{-# INLINE eth_blockNumber #-}
-{-# INLINE eth_getBlockTransactionCountByNumber #-}
-{-# INLINE eth_gasPrice #-}
-{-# INLINE eth_getUncleByBlockHashAndIndex #-}
-{-# INLINE eth_getUncleByBlockNumberAndIndex #-}
-{-# INLINE eth_newPendingTransactionFilter #-}
-{-# INLINE eth_getFilterLogs #-}
-{-# INLINE eth_getWork #-}
-{-# INLINE eth_submitWork #-}
 {-# INLINE eth_submitHashrate #-}
+eth_submitHashrate = remote "eth_submitHashrate"

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -51,6 +51,11 @@ eth_uninstallFilter :: Provider a => FilterId -> Web3 a Bool
 {-# INLINE eth_uninstallFilter #-}
 eth_uninstallFilter = remote "eth_uninstallFilter"
 
+-- | Returns an array of all logs matching a given filter object.
+eth_getLogs :: Provider a => Filter -> Web3 a [Change]
+{-# INLINE eth_getLogs #-}
+eth_getLogs = remote "eth_getLogs"
+
 -- | Executes a new message call immediately without creating a
 -- transaction on the block chain.
 eth_call :: Provider a => Call -> CallMode -> Web3 a Text
@@ -82,3 +87,26 @@ eth_getBlockFilterChanges = remote "eth_getFilterChanges"
 eth_getBlockByHash :: Provider a => Text -> Web3 a Block
 {-# INLINE eth_getBlockByHash #-}
 eth_getBlockByHash = flip (remote "eth_getBlockByHash") True
+
+-- | Returns information about a block by block number.
+eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
+{-# INLINE eth_getBlockByNumber #-}
+eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
+
+-- | Returns the number of most recent block.
+eth_blockNumber :: Provider a => Web3 a Text
+{-# INLINE eth_blockNumber #-}
+eth_blockNumber = remote "eth_blockNumber"
+
+-- | Returns the number of transactions in a block matching the
+-- given block number.
+eth_getBlockTransactionCountByNumber :: Provider a => Text
+                                     -> Web3 a Text
+{-# INLINE eth_getBlockTransactionCountByNumber #-}
+eth_getBlockTransactionCountByNumber =
+    remote "eth_getBlockTransactionCountByNumber"
+
+-- | Returns the current price per gas in wei.
+eth_gasPrice :: Provider a => Web3 a Text
+{-# INLINE eth_gasPrice #-}
+eth_gasPrice = remote "eth_gasPrice"

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -147,16 +147,16 @@ eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
 eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 
 -- | Returns the information about a transaction requested by transaction hash.
-eth_getTransactionByHash :: Provider a => Text -> Web3 a Transaction
+eth_getTransactionByHash :: Provider a => Text -> Web3 a (Maybe Transaction)
 eth_getTransactionByHash = remote "eth_getBlockByHash"
 
 -- | Returns information about a transaction by block hash and transaction index position.
-eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text ->  Web3 a Transaction
+eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text ->  Web3 a (Maybe Transaction)
 eth_getTransactionByBlockHashAndIndex = remote "eth_getTransactionByBlockHashAndIndex"
 
 -- | Returns information about a transaction by block number and transaction
 -- index position.
-eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text ->  Web3 a Transaction
+eth_getTransactionByBlockNumberAndIndex :: Provider a => CallMode -> Text ->  Web3 a (Maybe Transaction)
 eth_getTransactionByBlockNumberAndIndex = remote "eth_getTransactionByBlockNumberAndIndex"
 
 -- | Returns a list of addresses owned by client.

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -53,9 +53,31 @@ eth_mining = remote "eth_mining"
 eth_hashrate :: Provider a => Web3 a Text
 eth_hashrate = remote "eth_hashrate"
 
+-- | Returns the value from a storage position at a given address.
+eth_getStorageAt :: Provider a => Address -> Text -> CallMode -> Web3 a Text
+eth_getStorageAt = remote "eth_getStorageAt"
+
 -- | Returns the number of transactions sent from an address.
 eth_getTransactionCount :: Provider a => Address -> CallMode -> Web3 a Text
 eth_getTransactionCount = remote "eth_getTransactionCount"
+
+-- | Returns the number of transactions in a block from a block matching the given block hash.
+eth_getBlockTransactionCountByHash :: Provider a => Web3 a Text
+eth_getBlockTransactionCountByHash = remote "eth_getBlockTransactionCountByHash"
+
+-- | Returns the number of transactions in a block matching the
+-- given block number.
+eth_getBlockTransactionCountByNumber :: Provider a => Text -> Web3 a Text
+eth_getBlockTransactionCountByNumber =
+    remote "eth_getBlockTransactionCountByNumber"
+
+-- | Returns the number of uncles in a block from a block matching the given
+-- block hash.
+eth_getUncleCountByBlockHash :: Provider a => Text -> Web3 a Text
+eth_getUncleCountByBlockHash = remote "eth_getUncleCountByBlockHash"
+
+eth_getUncleCountByBlockNumber :: Provider a => Text -> Web3 a Text
+eth_getUncleCountByBlockNumber = remote "eth_getUncleCountByBlockNumber"
 
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
@@ -124,13 +146,6 @@ eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 eth_blockNumber :: Provider a => Web3 a Text
 eth_blockNumber = remote "eth_blockNumber"
 
--- | Returns the number of transactions in a block matching the
--- given block number.
-eth_getBlockTransactionCountByNumber :: Provider a => Text
-                                     -> Web3 a Text
-eth_getBlockTransactionCountByNumber =
-    remote "eth_getBlockTransactionCountByNumber"
-
 -- | Returns the current price per gas in wei.
 eth_gasPrice :: Provider a => Web3 a Text
 eth_gasPrice = remote "eth_gasPrice"
@@ -144,7 +159,11 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_coinbase #-}
 {-# INLINE eth_mining #-}
 {-# INLINE eth_hashrate #-}
+{-# INLINE eth_getStorageAt #-}
 {-# INLINE eth_getTransactionCount #-}
+{-# INLINE eth_getBlockTransactionCountByHash #-}
+{-# INLINE eth_getUncleCountByBlockHash #-}
+{-# INLINE eth_getUncleCountByBlockNumber #-}
 {-# INLINE eth_getBalance #-}
 {-# INLINE eth_newFilter #-}
 {-# INLINE eth_getFilterChanges #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -53,6 +53,7 @@ eth_mining = remote "eth_mining"
 eth_hashrate :: Provider a => Web3 a Text
 eth_hashrate = remote "eth_hashrate"
 
+-- | Returns the number of transactions sent from an address.
 eth_getTransactionCount :: Provider a => Address -> CallMode -> Web3 a Text
 eth_getTransactionCount = remote "eth_getTransactionCount"
 
@@ -85,9 +86,14 @@ eth_getLogs = remote "eth_getLogs"
 eth_call :: Provider a => Call -> CallMode -> Web3 a Text
 eth_call = remote "eth_call"
 
--- TODO make bytes32 concatenation easy! otherwise signatures will be a pain
+-- | Returns an Ethereum specific signature with:
+-- sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))).
 eth_sign :: Provider a => Address -> Text -> Web3 a Text
 eth_sign = remote "eth_sign"
+
+-- | Returns code at a given address.
+eth_getCode :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getCode = remote "eth_getCode"
 
 -- | Creates new message call transaction or a contract creation,
 -- if the data field contains code.
@@ -146,6 +152,7 @@ eth_gasPrice = remote "eth_gasPrice"
 {-# INLINE eth_getLogs #-}
 {-# INLINE eth_call #-}
 {-# INLINE eth_sign #-}
+{-# INLINE eth_getCode #-}
 {-# INLINE eth_sendTransaction #-}
 {-# INLINE eth_accounts #-}
 {-# INLINE eth_newBlockFilter #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -184,6 +184,24 @@ eth_blockNumber = remote "eth_blockNumber"
 eth_gasPrice :: Provider a => Web3 a Text
 eth_gasPrice = remote "eth_gasPrice"
 
+-- | Returns information about a uncle of a block by hash and uncle index
+-- position.
+eth_getUncleByBlockHashAndIndex :: Provider a => Text -> Text -> Web3 a Block
+eth_getUncleByBlockHashAndIndex = remote "eth_getUncleByBlockHashAndIndex"
+
+-- | Returns information about a uncle of a block by number and uncle index
+-- position.
+eth_getUncleByBlockNumberAndIndex :: Provider a => DefaultBlock -> Text -> Web3 a Block
+eth_getUncleByBlockNumberAndIndex = remote "eth_getUncleByBlockNumberAndIndex"
+
+-- | Creates a filter in the node, to notify when new pending transactions arrive. To check if the state has changed, call eth_getFilterChanges. Returns a FilterId.
+eth_newPendingTransactionFilter :: Provider a => Web3 a Text
+eth_newPendingTransactionFilter = remote "eth_newPendingTransactionFilter"
+
+-- | Returns an array of all logs matching filter with given id.
+eth_getFilterLogs :: Provider a => Text -> Web3 a [Change]
+eth_getFilterLogs = remote "eth_getFilterLogs"
+
 -- | Returns the hash of the current block, the seedHash, and the boundary
 -- condition to be met ("target").
 eth_getWork :: Provider a => Web3 a [Text]
@@ -240,6 +258,10 @@ eth_submitHashrate = remote "eth_submitHashrate"
 {-# INLINE eth_blockNumber #-}
 {-# INLINE eth_getBlockTransactionCountByNumber #-}
 {-# INLINE eth_gasPrice #-}
+{-# INLINE eth_getUncleByBlockHashAndIndex #-}
+{-# INLINE eth_getUncleByBlockNumberAndIndex #-}
+{-# INLINE eth_newPendingTransactionFilter #-}
+{-# INLINE eth_getFilterLogs #-}
 {-# INLINE eth_getWork #-}
 {-# INLINE eth_submitWork #-}
 {-# INLINE eth_submitHashrate #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -41,6 +41,10 @@ net_peerCount = remote "net_peerCount"
 eth_protocolVersion :: Provider a => Web3 a Text
 eth_protocolVersion = remote "eth_protocolVersion"
 
+-- TODO The return type of this function requires a new type to be created
+-- | Returns an object with data about the sync status or false.
+-- eth_syncing :: Proviver a => Web3 a Text
+
 -- | Returns the client coinbase address.
 eth_coinbase :: Provider a => Web3 a Address
 eth_coinbase = remote "eth_coinbase"
@@ -76,8 +80,24 @@ eth_getBlockTransactionCountByNumber =
 eth_getUncleCountByBlockHash :: Provider a => Text -> Web3 a Text
 eth_getUncleCountByBlockHash = remote "eth_getUncleCountByBlockHash"
 
+-- | Returns the number of uncles in a block from a block matching the given
+-- block number.
 eth_getUncleCountByBlockNumber :: Provider a => Text -> Web3 a Text
 eth_getUncleCountByBlockNumber = remote "eth_getUncleCountByBlockNumber"
+
+-- | Returns code at a given address.
+eth_getCode :: Provider a => Address -> CallMode -> Web3 a Text
+eth_getCode = remote "eth_getCode"
+
+-- | Returns an Ethereum specific signature with:
+-- sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))).
+eth_sign :: Provider a => Address -> Text -> Web3 a Text
+eth_sign = remote "eth_sign"
+
+-- | Creates new message call transaction or a contract creation,
+-- if the data field contains code.
+eth_sendTransaction :: Provider a => Call -> Web3 a Text
+eth_sendTransaction = remote "eth_sendTransaction"
 
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
@@ -107,20 +127,6 @@ eth_getLogs = remote "eth_getLogs"
 -- transaction on the block chain.
 eth_call :: Provider a => Call -> CallMode -> Web3 a Text
 eth_call = remote "eth_call"
-
--- | Returns an Ethereum specific signature with:
--- sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))).
-eth_sign :: Provider a => Address -> Text -> Web3 a Text
-eth_sign = remote "eth_sign"
-
--- | Returns code at a given address.
-eth_getCode :: Provider a => Address -> CallMode -> Web3 a Text
-eth_getCode = remote "eth_getCode"
-
--- | Creates new message call transaction or a contract creation,
--- if the data field contains code.
-eth_sendTransaction :: Provider a => Call -> Web3 a Text
-eth_sendTransaction = remote "eth_sendTransaction"
 
 -- | Returns a list of addresses owned by client.
 eth_accounts :: Provider a => Web3 a [Address]

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -19,133 +19,135 @@ import Data.Text (Text)
 
 -- | Returns current node version string.
 web3_clientVersion :: Provider a => Web3 a Text
-{-# INLINE web3_clientVersion #-}
 web3_clientVersion = remote "web3_clientVersion"
 
 -- | Returns Keccak-256 (not the standardized SHA3-256) of the given data.
 web3_sha3 :: Provider a => Text -> Web3 a Text
-{-# INLINE web3_sha3 #-}
 web3_sha3 = remote "web3_sha3"
 
 -- | Returns the current network id.
 net_version :: Provider a => Web3 a Text
-{-# INLINE net_version #-}
 net_version = remote "net_version"
 
 -- | Returns true if client is actively listening for network connections.
 net_listening :: Provider a => Web3 a Bool
-{-# INLINE net_listening #-}
 net_listening = remote "net_listening"
 
 -- | Returns number of peers currently connected to the client.
 net_peerCount :: Provider a => Web3 a Text
-{-# INLINE net_peerCount #-}
 net_peerCount = remote "net_peerCount"
 
 -- | Returns the current ethereum protocol version.
 eth_protocolVersion :: Provider a => Web3 a Text
-{-# INLINE eth_protocolVersion #-}
 eth_protocolVersion = remote "eth_protocolVersion"
 
 -- | Returns the client coinbase address.
 eth_coinbase :: Provider a => Web3 a Address
-{-# INLINE eth_coinbase #-}
 eth_coinbase = remote "eth_coinbase"
 
 -- | Returns true if client is actively mining new blocks.
 eth_mining :: Provider a => Web3 a Bool
-{-# INLINE eth_mining #-}
 eth_mining = remote "eth_mining"
 
 -- | Returns the number of hashes per second that the node is mining with.
 eth_hashrate :: Provider a => Web3 a Text
-{-# INLINE eth_hashrate #-}
 eth_hashrate = remote "eth_hashrate"
 
 -- | Returns the balance of the account of given address.
 eth_getBalance :: Provider a => Address -> CallMode -> Web3 a Text
-{-# INLINE eth_getBalance #-}
 eth_getBalance = remote "eth_getBalance"
 
 -- | Creates a filter object, based on filter options, to notify when the
 -- state changes (logs). To check if the state has changed, call
 -- 'getFilterChanges'.
 eth_newFilter :: Provider a => Filter -> Web3 a FilterId
-{-# INLINE eth_newFilter #-}
 eth_newFilter = remote "eth_newFilter"
 
 -- | Polling method for a filter, which returns an array of logs which
 -- occurred since last poll.
 eth_getFilterChanges :: Provider a => FilterId -> Web3 a [Change]
-{-# INLINE eth_getFilterChanges #-}
 eth_getFilterChanges = remote "eth_getFilterChanges"
 
 -- | Uninstalls a filter with given id.
 -- Should always be called when watch is no longer needed.
 eth_uninstallFilter :: Provider a => FilterId -> Web3 a Bool
-{-# INLINE eth_uninstallFilter #-}
 eth_uninstallFilter = remote "eth_uninstallFilter"
 
 -- | Returns an array of all logs matching a given filter object.
 eth_getLogs :: Provider a => Filter -> Web3 a [Change]
-{-# INLINE eth_getLogs #-}
 eth_getLogs = remote "eth_getLogs"
 
 -- | Executes a new message call immediately without creating a
 -- transaction on the block chain.
 eth_call :: Provider a => Call -> CallMode -> Web3 a Text
-{-# INLINE eth_call #-}
 eth_call = remote "eth_call"
 
+-- TODO make bytes32 concatenation easy! otherwise signatures will be a pain
 eth_sign :: Provider a => Address -> Text -> Web3 a Text
-{-# INLINE eth_sign #-}
 eth_sign = remote "eth_sign"
 
 -- | Creates new message call transaction or a contract creation,
 -- if the data field contains code.
 eth_sendTransaction :: Provider a => Call -> Web3 a Text
-{-# INLINE eth_sendTransaction #-}
 eth_sendTransaction = remote "eth_sendTransaction"
 
 -- | Returns a list of addresses owned by client.
 eth_accounts :: Provider a => Web3 a [Address]
-{-# INLINE eth_accounts #-}
 eth_accounts = remote "eth_accounts"
 
 eth_newBlockFilter :: Provider a => Web3 a Text
-{-# INLINE eth_newBlockFilter #-}
 eth_newBlockFilter = remote "eth_newBlockFilter"
 
 -- | Polling method for a block filter, which returns an array of block hashes
 -- occurred since last poll.
 eth_getBlockFilterChanges :: Provider a => Text -> Web3 a [Text]
-{-# INLINE eth_getBlockFilterChanges #-}
 eth_getBlockFilterChanges = remote "eth_getFilterChanges"
 
 -- | Returns information about a block by hash.
 eth_getBlockByHash :: Provider a => Text -> Web3 a Block
-{-# INLINE eth_getBlockByHash #-}
 eth_getBlockByHash = flip (remote "eth_getBlockByHash") True
 
 -- | Returns information about a block by block number.
 eth_getBlockByNumber :: Provider a => Text -> Web3 a Block
-{-# INLINE eth_getBlockByNumber #-}
 eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 
 -- | Returns the number of most recent block.
 eth_blockNumber :: Provider a => Web3 a Text
-{-# INLINE eth_blockNumber #-}
 eth_blockNumber = remote "eth_blockNumber"
 
 -- | Returns the number of transactions in a block matching the
 -- given block number.
 eth_getBlockTransactionCountByNumber :: Provider a => Text
                                      -> Web3 a Text
-{-# INLINE eth_getBlockTransactionCountByNumber #-}
 eth_getBlockTransactionCountByNumber =
     remote "eth_getBlockTransactionCountByNumber"
 
 -- | Returns the current price per gas in wei.
 eth_gasPrice :: Provider a => Web3 a Text
-{-# INLINE eth_gasPrice #-}
 eth_gasPrice = remote "eth_gasPrice"
+
+{-# INLINE web3_clientVersion #-}
+{-# INLINE web3_sha3 #-}
+{-# INLINE net_version #-}
+{-# INLINE net_listening #-}
+{-# INLINE net_peerCount #-}
+{-# INLINE eth_protocolVersion #-}
+{-# INLINE eth_coinbase #-}
+{-# INLINE eth_mining #-}
+{-# INLINE eth_hashrate #-}
+{-# INLINE eth_getBalance #-}
+{-# INLINE eth_newFilter #-}
+{-# INLINE eth_getFilterChanges #-}
+{-# INLINE eth_uninstallFilter #-}
+{-# INLINE eth_getLogs #-}
+{-# INLINE eth_call #-}
+{-# INLINE eth_sign #-}
+{-# INLINE eth_sendTransaction #-}
+{-# INLINE eth_accounts #-}
+{-# INLINE eth_newBlockFilter #-}
+{-# INLINE eth_getBlockFilterChanges #-}
+{-# INLINE eth_getBlockByHash #-}
+{-# INLINE eth_getBlockByNumber #-}
+{-# INLINE eth_blockNumber #-}
+{-# INLINE eth_getBlockTransactionCountByNumber #-}
+{-# INLINE eth_gasPrice #-}

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -148,7 +148,7 @@ eth_getBlockByNumber = flip (remote "eth_getBlockByNumber") True
 
 -- | Returns the information about a transaction requested by transaction hash.
 eth_getTransactionByHash :: Provider a => Text -> Web3 a (Maybe Transaction)
-eth_getTransactionByHash = remote "eth_getBlockByHash"
+eth_getTransactionByHash = remote "eth_getTransactionByHash"
 
 -- | Returns information about a transaction by block hash and transaction index position.
 eth_getTransactionByBlockHashAndIndex :: Provider a => Text -> Text ->  Web3 a (Maybe Transaction)

--- a/src/Network/Ethereum/Web3/Api.hs
+++ b/src/Network/Ethereum/Web3/Api.hs
@@ -66,7 +66,7 @@ eth_getTransactionCount :: Provider a => Address -> CallMode -> Web3 a Text
 eth_getTransactionCount = remote "eth_getTransactionCount"
 
 -- | Returns the number of transactions in a block from a block matching the given block hash.
-eth_getBlockTransactionCountByHash :: Provider a => Web3 a Text
+eth_getBlockTransactionCountByHash :: Provider a => Text -> Web3 a Text
 eth_getBlockTransactionCountByHash = remote "eth_getBlockTransactionCountByHash"
 
 -- | Returns the number of transactions in a block matching the

--- a/src/Network/Ethereum/Web3/Contract.hs
+++ b/src/Network/Ethereum/Web3/Contract.hs
@@ -120,7 +120,7 @@ class ABIEncoding a => Method a where
     call :: (Provider p, ABIEncoding b)
          => Address
          -- ^ Contract address
-         -> CallMode
+         -> DefaultBlock
          -- ^ State mode for constant call (latest or pending)
          -> a
          -- ^ Method data
@@ -138,7 +138,7 @@ _sendTransaction to value dat = do
         defaultGas  = "0x2DC2DC"
 
 _call :: (Provider p, Method a, ABIEncoding b)
-      => Address -> CallMode -> a -> Web3 p b
+      => Address -> DefaultBlock -> a -> Web3 p b
 _call to mode dat = do
     primeAddress <- listToMaybe <$> eth_accounts
     res <- eth_call (txdata primeAddress) mode

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -10,7 +10,7 @@
 -- Stability   :  experimental
 -- Portability :  portable
 --
--- Common used types and instances.
+-- Commonly used types and instances.
 --
 module Network.Ethereum.Web3.Types where
 
@@ -64,7 +64,7 @@ data Filter = Filter
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 6 }) ''Filter)
 
--- | Event filder ident
+-- | Event filter identifier
 newtype FilterId = FilterId Integer
   deriving (Show, Eq, Ord)
 
@@ -80,7 +80,8 @@ instance ToJSON FilterId where
         let hexValue = B.toLazyText (B.hexadecimal x)
         in  toJSON ("0x" <> hexValue)
 
--- | Changes pulled by low-level call 'eth_getFilterChanges'
+-- | Changes pulled by low-level call 'eth_getFilterChanges', 'eth_getLogs',
+-- and 'eth_getFilterLogs'
 data Change = Change
   { changeLogIndex         :: !Text
   , changeTransactionIndex :: !Text

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -109,11 +109,12 @@ $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 4 }) ''Call)
 
 -- | The contract call mode describe used state: latest or pending
-data CallMode = Latest | Pending
+data CallMode = BlockNumberHex Text | Earliest | Latest | Pending
   deriving (Show, Eq)
 
 instance ToJSON CallMode where
-    toJSON = toJSON . toLowerFirst . show
+    toJSON (BlockNumberHex hex) = toJSON hex
+    toJSON parameter = toJSON . toLowerFirst . show $ parameter
 
 -- TODO: Wrap
 -- | Transaction hash text string

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -109,10 +109,10 @@ $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 4 }) ''Call)
 
 -- | The contract call mode describe used state: latest or pending
-data CallMode = BlockNumberHex Text | Earliest | Latest | Pending
+data DefaultBlock = BlockNumberHex Text | Earliest | Latest | Pending
   deriving (Show, Eq)
 
-instance ToJSON CallMode where
+instance ToJSON DefaultBlock where
     toJSON (BlockNumberHex hex) = toJSON hex
     toJSON parameter = toJSON . toLowerFirst . show $ parameter
 


### PR DESCRIPTION
I want to add many more methods to make this library support the entire JSON RPC API, but first I need to get a feel for all the features of the library and ask a few questions.

Is the `INLINE` pragma useful in `Api.hs`? Does it only buy users of the library some efficiency or is necessary for some other reason? I ran a few tests and the functions seemed to work without it.