### PR TITLE
omitting `Nothing` fields in `Call`'s JSON representation

### DIFF
--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -106,7 +106,8 @@ data Call = Call
   } deriving Show
 
 $(deriveJSON (defaultOptions
-    { fieldLabelModifier = toLowerFirst . drop 4 }) ''Call)
+    { fieldLabelModifier = toLowerFirst . drop 4
+    , omitNothingFields = True }) ''Call)
 
 -- | The contract call mode describe used state: latest or pending
 data CallMode = Latest | Pending


### PR DESCRIPTION
Including `null` fields causes errors when using geth.

fixes #18.