### PR TITLE
Call argument to sendTransaction and call

### DIFF
--- a/src/Network/Ethereum/Unit.hs
+++ b/src/Network/Ethereum/Unit.hs
@@ -80,7 +80,7 @@ class UnitSpec a where
     name    :: Value a -> Text
 
 -- | Value abstraction
-data Value a = MkValue { unValue :: Integer }
+newtype Value a = MkValue { unValue :: Integer }
   deriving (Eq, Ord, Generic)
 
 mkValue :: (UnitSpec a, RealFrac b) => b -> Value a

--- a/src/Network/Ethereum/Unit.hs
+++ b/src/Network/Ethereum/Unit.hs
@@ -45,6 +45,7 @@
 --
 module Network.Ethereum.Unit (
     Unit(..)
+  , UnitSpec(..)
   , Wei
   , Babbage
   , Lovelace

--- a/src/Network/Ethereum/Web3/Contract.hs
+++ b/src/Network/Ethereum/Web3/Contract.hs
@@ -128,12 +128,12 @@ class ABIEncoding a => Method a where
 
 _sendTransaction :: (Provider p, Method a)
                  => Call -> a -> Web3 p TxHash
-_sendTransaction call dat = Eth.sendTransaction call
+_sendTransaction call dat = Eth.sendTransaction (call { callData = Just $ toData dat })
 
 _call :: (Provider p, Method a, ABIEncoding b)
       => Call -> DefaultBlock -> a -> Web3 p b
 _call call mode dat = do
-    res <- Eth.call call mode
+    res <- Eth.call (call { callData = Just $ toData dat }) mode
     case fromData (T.drop 2 res) of
         Nothing -> liftIO $ throwIO $ ParserFail $
             "Unable to parse result on `" ++ T.unpack res

--- a/src/Network/Ethereum/Web3/Encoding/Internal.hs
+++ b/src/Network/Ethereum/Web3/Encoding/Internal.hs
@@ -74,8 +74,8 @@ alignL = fst . align
 {-# INLINE alignR #-}
 alignR = snd . align
 
-toUInt256HexText :: Integral a => a -> Text
-toUInt256HexText = T.append "0x" . LT.toStrict . toLazyText . B.hexadecimal
+toQuantityHexText :: Integral a => a -> Text
+toQuantityHexText = T.append "0x" . LT.toStrict . toLazyText . B.hexadecimal
 
 int256HexBuilder :: Integral a => a -> Builder
 int256HexBuilder x

--- a/src/Network/Ethereum/Web3/Encoding/Internal.hs
+++ b/src/Network/Ethereum/Web3/Encoding/Internal.hs
@@ -74,6 +74,9 @@ alignL = fst . align
 {-# INLINE alignR #-}
 alignR = snd . align
 
+toUInt256HexText :: Integral a => a -> Text
+toUInt256HexText = T.append "0x" . LT.toStrict . toLazyText . B.hexadecimal
+
 int256HexBuilder :: Integral a => a -> Builder
 int256HexBuilder x
   | x < 0 = int256HexBuilder (2^256 + fromIntegral x)

--- a/src/Network/Ethereum/Web3/TH.hs
+++ b/src/Network/Ethereum/Web3/TH.hs
@@ -204,7 +204,7 @@ funWrapper c name dname args result = do
     sequence $ if c
         then
           [ sigD name $ [t|Provider $p =>
-                            $(arrowing $ [t|Address|] : inputT ++ [outputT])
+                            $(arrowing $ [t|Call|] : inputT ++ [outputT])
                           |]
           , funD' name (varP <$> a : vars) $
               case result of
@@ -213,11 +213,11 @@ funWrapper c name dname args result = do
           ]
 
         else
-          [ sigD name $ [t|(Provider $p, Unit $(varT b)) =>
-                            $(arrowing $ [t|Address|] : varT b : inputT ++ [[t|Web3 $p TxHash|]])
+          [ sigD name $ [t|(Provider $p) =>
+                            $(arrowing $ [t|Call|] : inputT ++ [[t|Web3 $p TxHash|]])
                           |]
-          , funD' name (varP <$> a : b : vars) $
-                [|sendTx $(varE a) $(varE b) $(params)|] ]
+          , funD' name (varP <$> a : vars) $
+                [|sendTx $(varE a) $(params)|] ]
   where
     p = varT (mkName "p")
     arrowing [x]      = x

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -29,6 +29,7 @@ import           Data.Typeable                  (Typeable)
 import           GHC.Generics
 import           Network.Ethereum.Web3.Address  (Address, zero)
 import           Network.Ethereum.Web3.Internal (toLowerFirst)
+import           Network.Ethereum.Web3.Encoding.Internal (toUInt256HexText)
 
 -- | Any communication with Ethereum node wrapped with 'Web3' monad
 newtype Web3 a b = Web3 { unWeb3 :: IO b }
@@ -99,13 +100,22 @@ data Change = Change
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 6 }) ''Change)
 
+newtype UInt256 = UInt256 { mkUInt256 :: Integer }
+    deriving (Show, Num, Integral, Real, Enum, Eq, Ord, Generic)
+
+instance ToJSON UInt256 where
+    toJSON = String . toUInt256HexText
+
+instance FromJSON UInt256 where
+    parseJSON = undefined
+
 -- | The contract call params
 data Call = Call
   { callFrom     :: !(Maybe Address)
   , callTo       :: !Address
-  , callGas      :: !(Maybe Integer)
-  , callGasPrice :: !(Maybe Integer)
-  , callValue    :: !(Maybe Integer) -- expressed in wei
+  , callGas      :: !(Maybe UInt256)
+  , callGasPrice :: !(Maybe UInt256)
+  , callValue    :: !(Maybe UInt256) -- expressed in wei
   , callData     :: !(Maybe Text)
   } deriving (Show, Generic)
 

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -70,13 +70,25 @@ $(deriveJSON (defaultOptions
 --  WRONG: 0x0400 (no leading zeroes allowed)
 --  WRONG: ff (must be prefixed 0x)
 newtype Quantity = Quantity { unQuantity :: Integer }
-    deriving (Show, Num, Integral, Real, Enum, Eq, Ord, Generic)
+    deriving (Show, Read, Num, Integral, Real, Enum, Eq, Ord, Generic)
 
 instance ToJSON Quantity where
     toJSON = String . toQuantityHexText
 
 instance FromJSON Quantity where
     parseJSON = undefined
+
+instance Fractional Quantity where
+    (/) a b = Quantity $ div (unQuantity a) (unQuantity b)
+    fromRational = Quantity . floor
+
+instance Unit Quantity where
+    fromWei = Quantity
+    toWei = unQuantity
+
+instance UnitSpec Quantity where
+    divider = const 1
+    name = const "quantity"
 
 -- | Low-level event filter data structure
 data Filter = Filter
@@ -137,10 +149,6 @@ $(deriveJSON (defaultOptions
 
 instance Default Call where
     def = Call Nothing zero (Just 3000000) Nothing (Just 0) Nothing
-
-
-setCallValue :: Unit a => a -> Call -> Call
-setCallValue value call = call { callValue = Just . Quantity $ toWei value }
 
 
 -- | The contract call mode describe used state: latest or pending

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -19,6 +19,7 @@ import           Control.Exception              (Exception)
 import           Control.Monad.IO.Class         (MonadIO)
 import           Data.Aeson
 import           Data.Aeson.TH
+import           Data.Default
 import           Data.Monoid                    ((<>))
 import           Data.Text                      (Text)
 import qualified Data.Text.Lazy.Builder         as B
@@ -26,7 +27,7 @@ import qualified Data.Text.Lazy.Builder.Int     as B
 import qualified Data.Text.Read                 as R
 import           Data.Typeable                  (Typeable)
 import           GHC.Generics
-import           Network.Ethereum.Web3.Address  (Address)
+import           Network.Ethereum.Web3.Address  (Address, zero)
 import           Network.Ethereum.Web3.Internal (toLowerFirst)
 
 -- | Any communication with Ethereum node wrapped with 'Web3' monad
@@ -102,15 +103,18 @@ $(deriveJSON (defaultOptions
 data Call = Call
   { callFrom     :: !(Maybe Address)
   , callTo       :: !Address
-  , callGas      :: !(Maybe Text)
-  , callGasPrice:: !(Maybe Text)
-  , callValue    :: !(Maybe Text)
+  , callGas      :: !(Maybe Integer)
+  , callGasPrice :: !(Maybe Integer)
+  , callValue    :: !(Maybe Integer) -- expressed in wei
   , callData     :: !(Maybe Text)
   } deriving (Show, Generic)
 
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = toLowerFirst . drop 4
     , omitNothingFields = True }) ''Call)
+
+instance Default Call where
+    def = Call Nothing zero (Just 3000000) Nothing (Just 0) Nothing
 
 -- | The contract call mode describe used state: latest or pending
 data DefaultBlock = BlockNumberHex Text | Earliest | Latest | Pending

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -30,6 +30,7 @@ import           GHC.Generics
 import           Network.Ethereum.Web3.Address  (Address, zero)
 import           Network.Ethereum.Web3.Internal (toLowerFirst)
 import           Network.Ethereum.Web3.Encoding.Internal (toQuantityHexText)
+import           Network.Ethereum.Unit
 
 -- | Any communication with Ethereum node wrapped with 'Web3' monad
 newtype Web3 a b = Web3 { unWeb3 :: IO b }
@@ -68,7 +69,7 @@ $(deriveJSON (defaultOptions
 --  WRONG: 0x (should always have at least one digit - zero is "0x0")
 --  WRONG: 0x0400 (no leading zeroes allowed)
 --  WRONG: ff (must be prefixed 0x)
-newtype Quantity = Quantity { mkQuantity :: Integer }
+newtype Quantity = Quantity { unQuantity :: Integer }
     deriving (Show, Num, Integral, Real, Enum, Eq, Ord, Generic)
 
 instance ToJSON Quantity where
@@ -136,6 +137,11 @@ $(deriveJSON (defaultOptions
 
 instance Default Call where
     def = Call Nothing zero (Just 3000000) Nothing (Just 0) Nothing
+
+
+setCallValue :: Unit a => a -> Call -> Call
+setCallValue value call = call { callValue = Just . Quantity $ toWei value }
+
 
 -- | The contract call mode describe used state: latest or pending
 data DefaultBlock = BlockNumberHex Text | Earliest | Latest | Pending

--- a/web3.cabal
+++ b/web3.cabal
@@ -49,6 +49,7 @@ library
                      , attoparsec
                      , bytestring
                      , cryptonite
+                     , data-default
                      , vector
                      , memory
                      , aeson


### PR DESCRIPTION
fixes #24.

- updating `call` and `sendTransaction` to take `Call` argument.
- creating `Quantity` type for JSON RPC calls. See the use of `QUANTITY` in the JSON RPC docs here: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call
    + This is better than using a Solidity type like `UInt256` because we shouldn't confuse JSON RPC types with what Solidity has available. Other EVM languages will be have different types, but JSON RPC will be for all!

POTENTIAL ADDITION: I don't think a `FromJSON` instance is necessary for `Quantity` or `Call` but TemplateHaskell yells at me if I don't include `parseJSON` for `Quantity`. I've left `Quantity`'s  `parseJSON = undefined` for now; I'll fill it in tomorrow if necessary.

code tested here: https://github.com/aupiff/hs-web3-playground/blob/86e4bf04b68d548e803a70e0b92afbf54d426eb1/web3-examples/app/Main.hs

Works with TH.