### PR TITLE
fix getBlockByHash and getBlockByNumber

### DIFF
--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -226,7 +226,7 @@ $(deriveJSON (defaultOptions
 
 -- | Block information
 data Block = Block
-  { blockBlockNumber      :: !BlockNumber
+  { blockNumber           :: !BlockNumber
   -- ^ QUANTITY - the block number. null when its pending block.
   , blockHash             :: !Text
   -- ^ DATA, 32 Bytes - hash of the block. null when its pending block.


### PR DESCRIPTION
I'm testing the [getBlockByHash](https://hackage.haskell.org/package/web3-0.6.0.0/docs/Network-Ethereum-Web3-Eth.html#v:getBlockByHash) function against infura main net like this

```
instance Provider PublicGeth where
  rpcUri = return "https://mainnet.infura.io/xxx

runWeb3' (getBlockByNumber "0x123" :: Web3 PublicGeth Block)
```

I got the following error:
```
Left (ParserFail "Error in $: When parsing the record Block of type Network.Ethereum.Web3.Types.Block the key blockNumber was not present.")
```

The reason is that [`getBlockByNumber` returns `number` instead of `blockNumber` as block number.](https://github.com/ethereum/wiki/wiki/JSON-RPC#returns-26)

Simply renaming the field of type `Block` fixes the bug.