### PR TITLE
TH: export mkDecl and escape

### DIFF
--- a/src/Network/Ethereum/Web3/TH.hs
+++ b/src/Network/Ethereum/Web3/TH.hs
@@ -37,6 +37,8 @@ module Network.Ethereum.Web3.TH (
   , IndexedEvent(..)
   , Tagged
   , module Generics.SOP
+  , mkDecl
+  , escape
   ) where
 
 import           Control.Monad                          ((<=<))


### PR DESCRIPTION
This enables development of custom QuasiQuoters like:

```haskell
import qualified Data.Text.Lazy                       as LT
import qualified Data.Text.Lazy.Encoding              as LT

import Data.Aeson

import Language.Haskell.TH
import Language.Haskell.TH.Lib
import Language.Haskell.TH.Quote

import Network.Ethereum.Web3.JsonAbi
import Network.Ethereum.Web3.Encoding
import Network.Ethereum.Web3.TH (mkDecl, escape)
import Network.Ethereum.Web3.Address

data TruffleABI = TruffleABI ContractABI String String

instance FromJSON TruffleABI where
  parseJSON = withObject "truffle" $ \t ->
    TruffleABI <$>
    t .: "abi" <*>
    t .: "contractName" <*>
    ((t .: "networks") >>= (.: "4447") >>= (.: "address"))

quoteAbiTruffleDec :: String -> Q [Dec]
quoteAbiTruffleDec abi_string
  = case eitherDecode abi_lbs of
      Right (TruffleABI (ContractABI abi) contractName address) ->
        liftM2
        (++)
        (concat <$> mapM mkDecl (escape abi))
        (let name = varP (mkName ("address_" ++ contractName ++ "_4447"))
             lit = LitE (stringL address)
          in fmap (:[]) (valD name (return (NormalB lit)) []))
      Left e  -> fail e
  where
    abi_lbs = LT.encodeUtf8 (LT.pack abi_string)

-- | Read contract ABI from file
truffleAbiFrom :: QuasiQuoter
truffleAbiFrom = quoteFile truffleAbi

-- | QQ reader for contract ABI
truffleAbi :: QuasiQuoter
truffleAbi = QuasiQuoter
  { quoteDec  = quoteAbiTruffleDec
  , quoteExp  = undefined
  , quotePat  = undefined
  , quoteType = undefined
  }
```