### PR TITLE
Updating rpc functions to use more descriptive `Quantity` type

### DIFF
--- a/src/Network/Ethereum/Web3/Eth.hs
+++ b/src/Network/Ethereum/Web3/Eth.hs
@@ -38,7 +38,7 @@ mining :: Web3 Bool
 mining = remote "eth_mining"
 
 -- | Returns the number of hashes per second that the node is mining with.
-hashrate :: Web3 Text
+hashrate :: Web3 Quantity
 {-# INLINE hashrate #-}
 hashrate = remote "eth_hashrate"
 
@@ -48,30 +48,30 @@ getStorageAt :: Address -> Text -> DefaultBlock -> Web3 Text
 getStorageAt = remote "eth_getStorageAt"
 
 -- | Returns the number of transactions sent from an address.
-getTransactionCount :: Address -> DefaultBlock -> Web3 Text
+getTransactionCount :: Address -> DefaultBlock -> Web3 Quantity
 {-# INLINE getTransactionCount #-}
 getTransactionCount = remote "eth_getTransactionCount"
 
 -- | Returns the number of transactions in a block from a block matching the given block hash.
-getBlockTransactionCountByHash :: Text -> Web3 Text
+getBlockTransactionCountByHash :: Text -> Web3 Quantity
 {-# INLINE getBlockTransactionCountByHash #-}
 getBlockTransactionCountByHash = remote "eth_getBlockTransactionCountByHash"
 
 -- | Returns the number of transactions in a block matching the
 -- given block number.
-getBlockTransactionCountByNumber :: Text -> Web3 Text
+getBlockTransactionCountByNumber :: Text -> Web3 Quantity
 {-# INLINE getBlockTransactionCountByNumber #-}
 getBlockTransactionCountByNumber = remote "eth_getBlockTransactionCountByNumber"
 
 -- | Returns the number of uncles in a block from a block matching the given
 -- block hash.
-getUncleCountByBlockHash :: Text -> Web3 Text
+getUncleCountByBlockHash :: Text -> Web3 Quantity
 {-# INLINE getUncleCountByBlockHash #-}
 getUncleCountByBlockHash = remote "eth_getUncleCountByBlockHash"
 
 -- | Returns the number of uncles in a block from a block matching the given
 -- block number.
-getUncleCountByBlockNumber :: Text -> Web3 Text
+getUncleCountByBlockNumber :: Text -> Web3 Quantity
 {-# INLINE getUncleCountByBlockNumber #-}
 getUncleCountByBlockNumber = remote "eth_getUncleCountByBlockNumber"
 
@@ -99,7 +99,7 @@ sendRawTransaction :: Text -> Web3 Text
 sendRawTransaction = remote "eth_sendRawTransaction"
 
 -- | Returns the balance of the account of given address.
-getBalance :: Address -> DefaultBlock -> Web3 Text
+getBalance :: Address -> DefaultBlock -> Web3 Quantity
 {-# INLINE getBalance #-}
 getBalance = remote "eth_getBalance"
 
@@ -135,7 +135,7 @@ call = remote "eth_call"
 
 -- | Makes a call or transaction, which won't be added to the blockchain and
 -- returns the used gas, which can be used for estimating the used gas.
-estimateGas :: Call -> Web3 Text
+estimateGas :: Call -> Web3 Quantity
 {-# INLINE estimateGas #-}
 estimateGas = remote "eth_estimateGas"
 
@@ -191,7 +191,7 @@ blockNumber :: Web3 BlockNumber
 blockNumber = remote "eth_blockNumber"
 
 -- | Returns the current price per gas in wei.
-gasPrice :: Web3 Text
+gasPrice :: Web3 Quantity
 {-# INLINE gasPrice #-}
 gasPrice = remote "eth_gasPrice"
 

--- a/src/Network/Ethereum/Web3/Net.hs
+++ b/src/Network/Ethereum/Web3/Net.hs
@@ -27,6 +27,6 @@ listening :: Web3 Bool
 listening = remote "net_listening"
 
 -- | Returns number of peers currently connected to the client.
-peerCount :: Web3 Text
+peerCount :: Web3 Quantity
 {-# INLINE peerCount #-}
 peerCount = remote "net_peerCount"

--- a/src/Network/Ethereum/Web3/Types.hs
+++ b/src/Network/Ethereum/Web3/Types.hs
@@ -92,7 +92,12 @@ instance ToJSON Quantity where
     toJSON = String . toQuantityHexText
 
 instance FromJSON Quantity where
-    parseJSON = undefined
+    parseJSON (String v) =
+        case R.hexadecimal v of
+            Right (x, "") -> return (Quantity x)
+            _             -> fail "Unable to parse Quantity"
+    parseJSON _ = fail "Quantity may only be parsed from a JSON String"
+
 
 instance Fractional Quantity where
     (/) a b = Quantity $ div (unQuantity a) (unQuantity b)


### PR DESCRIPTION
The `Quantity` type is used generally for integer values in web3 json rpc.

FYI: I was prompted to make this change because I am now using `getTransactionCount` to calculate tx nonces on the branch where I'm finally implementing offline transaction signing! PR for this will come shortly.