### PR TITLE
Handle overloaded events in `abi`

### DIFF
--- a/src/Network/Ethereum/ABI/Json.hs
+++ b/src/Network/Ethereum/ABI/Json.hs
@@ -89,13 +89,30 @@ instance Eq Declaration where
     (DConstructor a) == (DConstructor b) = length a == length b
     (DFunction a _ _ _) == (DFunction b _ _ _) = a == b
     (DEvent a _ _) == (DEvent b _ _) = a == b
-    (==) _ _ = True
+    (DFallback _) == (DFallback _) = True
+    (==) _ _ = False
 
 instance Ord Declaration where
     compare (DConstructor a) (DConstructor b) = compare (length a) (length b)
     compare (DFunction a _ _ _) (DFunction b _ _ _) = compare a b
     compare (DEvent a _ _) (DEvent b _ _) = compare a b
-    compare _ _ = EQ
+    compare (DFallback _) (DFallback _) = EQ
+
+    compare DConstructor {} DFunction {} = LT
+    compare DConstructor {} DEvent {} = LT
+    compare DConstructor {} DFallback {} = LT
+
+    compare DFunction {} DConstructor {} = GT
+    compare DFunction {} DEvent {} = LT
+    compare DFunction {} DFallback {} = LT
+
+    compare DEvent {} DConstructor {} = GT
+    compare DEvent {} DFunction {} = GT
+    compare DEvent {} DFallback {} = LT
+
+    compare DFallback {} DConstructor {} = GT
+    compare DFallback {} DFunction {} = GT
+    compare DFallback {} DEvent {} = GT
 
 $(deriveJSON (defaultOptions {
     sumEncoding = TaggedObject "type" "contents"

--- a/src/Network/Ethereum/Contract/TH.hs
+++ b/src/Network/Ethereum/Contract/TH.hs
@@ -250,6 +250,7 @@ escapeEqualNames = concat . fmap go . group . sort
         go (x : xs) = x : zipWith appendToName xs hats
         hats = [T.replicate n "'" | n <- [1..]]
         appendToName d@(DFunction n _ _ _) a = d { funName = n <> a }
+        appendToName d@(DEvent n _ _) a      = d { eveName = n <> a }
         appendToName d _                     = d
 
 escapeReservedNames :: Declaration -> Declaration


### PR DESCRIPTION
I noticed that multiple events with the same name are not handled properly. In that case `abi` would generate conflicting data type definitions. I took a stab at fixing this myself.