### PR TITLE
Implementing offnode signing

### DIFF
--- a/src/Network/Ethereum/ABI/Prim/Address.hs
+++ b/src/Network/Ethereum/ABI/Prim/Address.hs
@@ -16,6 +16,7 @@
 
 module Network.Ethereum.ABI.Prim.Address (
     Address
+  , toHexString
   ) where
 
 import           Control.Monad                 ((<=<))

--- a/src/Network/Ethereum/Contract/Method.hs
+++ b/src/Network/Ethereum/Contract/Method.hs
@@ -18,17 +18,20 @@ module Network.Ethereum.Contract.Method (
   , sendTx
   ) where
 
-import           Control.Monad.Catch             (throwM)
-import           Data.Monoid                     ((<>))
-import           Data.Proxy                      (Proxy (..))
+import           Control.Monad.Catch               (throwM)
+import           Control.Monad.Reader
+import           Data.Monoid                       ((<>))
+import           Data.Proxy                        (Proxy (..))
 
-import           Network.Ethereum.ABI.Class      (ABIGet, ABIPut, ABIType (..))
-import           Network.Ethereum.ABI.Codec      (decode, encode)
-import           Network.Ethereum.ABI.Prim.Bytes (Bytes)
-import qualified Network.Ethereum.Web3.Eth       as Eth
-import           Network.Ethereum.Web3.Provider  (Web3, Web3Error (ParserFail))
-import           Network.Ethereum.Web3.Types     (Call (callData), DefaultBlock,
-                                                  Hash)
+import           Network.Ethereum.ABI.Class        (ABIGet, ABIPut, ABIType (..))
+import           Network.Ethereum.ABI.Codec        (decode, encode)
+import           Network.Ethereum.ABI.Prim.Bytes   (Bytes)
+import qualified Network.Ethereum.Web3.Eth         as Eth
+import           Network.Ethereum.Web3.Provider    (Provider (..), SigningConfiguration (..),
+                                                    Web3, Web3Error (ParserFail, UserFail))
+import           Network.Ethereum.Web3.Transaction (createRawTransaction)
+import           Network.Ethereum.Web3.Types       (Call (callData), DefaultBlock,
+                                                    Hash)
 
 class ABIPut a => Method a where
   selector :: Proxy a -> Bytes
@@ -49,9 +52,15 @@ sendTx :: Method a
        -> a
        -- ^ method data
        -> Web3 Hash
-sendTx call' (dat :: a) =
+sendTx call' (dat :: a) = do
     let sel = selector (Proxy :: Proxy a)
-    in Eth.sendTransaction (call' { callData = Just $ sel <> encode dat })
+    signingConfigM <- asks (signingConfiguration . fst)
+    case signingConfigM of
+        Just (SigningConfiguration privKey chainId) -> do
+            txBytes <- maybe (throwM $ UserFail "Unable to create raw transaction") return $
+                createRawTransaction (call' { callData = Just $ sel <> encode dat }) chainId privKey
+            Eth.sendRawTransaction txBytes
+        Nothing -> Eth.sendTransaction (call' { callData = Just $ sel <> encode dat })
 
 -- | 'call' is used to call contract methods that have no state changing effects.
 call :: (Method a, ABIGet b)

--- a/src/Network/Ethereum/Contract/Method.hs
+++ b/src/Network/Ethereum/Contract/Method.hs
@@ -57,7 +57,7 @@ sendTx call' (dat :: a) = do
     signingConfigM <- asks (signingConfiguration . fst)
     case signingConfigM of
         Just (SigningConfiguration privKey chainId) -> do
-            txBytes <- maybe (throwM $ UserFail "Unable to create raw transaction") return $
+            txBytes <- either (throwM . UserFail) pure $
                 createRawTransaction (call' { callData = Just $ sel <> encode dat }) chainId privKey
             Eth.sendRawTransaction txBytes
         Nothing -> Eth.sendTransaction (call' { callData = Just $ sel <> encode dat })

--- a/src/Network/Ethereum/Web3/Provider.hs
+++ b/src/Network/Ethereum/Web3/Provider.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Catch        (MonadThrow)
 import           Control.Monad.IO.Class     (MonadIO (..))
 import           Control.Monad.Reader       (MonadReader (..))
 import           Control.Monad.Trans.Reader (ReaderT, mapReaderT, runReaderT)
-import           Data.Aeson                 (FromJSON)
+import           Data.ByteString            (ByteString)
 import           Data.Default               (Default (..))
 import           GHC.Generics               (Generic)
 import           Network.HTTP.Client        (Manager, newManager)
@@ -35,17 +35,13 @@ import           Network.HTTP.Client.TLS    (tlsManagerSettings)
 import           Network.HTTP.Client        (defaultManagerSettings)
 #endif
 
-import           Network.JsonRpc.TinyClient (Remote, ServerUri)
-
 -- | Any communication with Ethereum node wrapped with 'Web3' monad
-newtype Web3 a = Web3 { unWeb3 :: ReaderT (ServerUri, Manager) IO a }
+newtype Web3 a = Web3 { unWeb3 :: ReaderT (Provider, Manager) IO a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadThrow)
 
-instance MonadReader (ServerUri, Manager) Web3 where
+instance MonadReader (Provider, Manager) Web3 where
     ask = Web3 ask
     local f = Web3 . local f . unWeb3
-
-instance FromJSON a => Remote Web3 (Web3 a)
 
 -- | Some peace of error response
 data Web3Error
@@ -59,18 +55,28 @@ data Web3Error
 
 instance Exception Web3Error
 
+-- | JSON-RPC server URI
+type ServerUri  = String
+
 --TODO: Change to `HttpProvider ServerUri | IpcProvider FilePath` to support IPC
--- | Web3 Provider
-data Provider = HttpProvider ServerUri
+data JsonRpcProvider = HttpProvider ServerUri
   deriving (Show, Eq, Generic)
 
+-- | Web3 Provider
+data Provider = Provider { jsonRpc :: JsonRpcProvider
+                         , signingConfiguration :: Maybe SigningConfiguration
+                         }
+
+data SigningConfiguration = SigningConfiguration { privateKey      :: ByteString
+                                                 , chainIdentifier :: Integer }
+
 instance Default Provider where
-  def = HttpProvider "http://localhost:8545"
+  def = Provider (HttpProvider "http://localhost:8545") Nothing
 
 -- | 'Web3' monad runner, using the supplied Manager
 runWeb3With :: MonadIO m => Manager -> Provider -> Web3 a -> m (Either Web3Error a)
-runWeb3With manager (HttpProvider uri) f =
-    liftIO . try .  flip runReaderT (uri, manager) . unWeb3 $ f
+runWeb3With manager provider f =
+    liftIO . try .  flip runReaderT (provider, manager) . unWeb3 $ f
 
 -- | 'Web3' monad runner
 runWeb3' :: MonadIO m => Provider -> Web3 a -> m (Either Web3Error a)

--- a/src/Network/Ethereum/Web3/Transaction.hs
+++ b/src/Network/Ethereum/Web3/Transaction.hs
@@ -34,7 +34,7 @@ createRawTransaction call chainId privateKey = do
                                             , 0 :: Integer
                                             , 0 :: Integer
                                             )
-    let rlpHash = convert (hash rlpEndcoding :: Digest Keccak_256)
+        rlpHash = convert (hash rlpEndcoding :: Digest Keccak_256)
     recSig <- ecsign rlpHash privateKey
     let r = fromShort $ getCompactRecSigR recSig
         s = fromShort $ getCompactRecSigS recSig

--- a/src/Network/Ethereum/Web3/Transaction.hs
+++ b/src/Network/Ethereum/Web3/Transaction.hs
@@ -3,10 +3,10 @@ module Network.Ethereum.Web3.Transaction where
 import           Crypto.Hash                       (Digest, Keccak_256, hash)
 import           Crypto.Secp256k1
 import           Data.ByteArray                    (Bytes, convert)
+import           Data.ByteArray.Encoding
 import           Data.ByteString
 import qualified Data.ByteString                   as BS
 import           Data.ByteString.Short             (fromShort)
-import qualified Data.ByteString.Base16            as BS16
 import           Data.Maybe                        (fromMaybe)
 import           Data.RLP
 import           Network.Ethereum.Web3.Types
@@ -17,10 +17,10 @@ unpackCallParameters call = do
     nonce <- toError "nonce" $ unQuantity <$> callNonce call
     gasPrice <- toError "gasPrice" $ unQuantity <$> callGasPrice call
     gasLimit <- toError "gas" $ unQuantity <$> callGas call
-    to <- toError "to" $ (fst . BS16.decode . BS.drop 2 . toHexString <$> callTo call)
-    value <- toError "value" $ (unQuantity <$> callValue call)
+    to <- convertFromBase Base16 =<< toError "to" (BS.drop 2 . toHexString <$> callTo call)
+    value <- toError "value" (unQuantity <$> callValue call)
     let txData = fromMaybe empty $ convert <$> callData call
-    return $ (nonce, gasPrice, gasLimit, to, value, txData)
+    return (nonce, gasPrice, gasLimit, to, value, txData)
         where toError field =
                 maybe (Left $ field ++ " must be set when creating raw transaction") pure
 

--- a/src/Network/Ethereum/Web3/Transaction.hs
+++ b/src/Network/Ethereum/Web3/Transaction.hs
@@ -1,0 +1,65 @@
+module Network.Ethereum.Web3.Transaction where
+
+import           Crypto.Hash                       (Digest, Keccak_256, hash)
+import           Crypto.Secp256k1
+import           Data.ByteArray                    (Bytes, convert)
+import           Data.ByteString
+import qualified Data.ByteString                   as BS
+import           Data.ByteString.Short             (fromShort)
+import qualified Data.ByteString.Base16            as BS16
+import           Data.Maybe                        (fromMaybe)
+import           Data.RLP
+import           Network.Ethereum.Web3.Types
+import           Network.Ethereum.ABI.Prim.Address (toHexString)
+
+unpackCallParameters :: Call -> Maybe (Integer, Integer, Integer, ByteString, Integer, ByteString)
+unpackCallParameters call = (,,,,,) <$> (unQuantity <$> callNonce call)
+                                    <*> (unQuantity <$> callGasPrice call)
+                                    <*> (unQuantity <$> callGas call)
+                                    <*> (fst . BS16.decode . BS.drop 2 . toHexString <$> callTo call)
+                                    <*> (unQuantity <$> callValue call)
+                                    <*> (pure . fromMaybe empty $ convert <$> callData call)
+
+-- initial rlpHash of transaction data
+rlpHashTransaction :: Call -> Integer -> Maybe ByteString
+rlpHashTransaction call chainId = do
+    (nonce, gasPrice, gasLimit, to, value, txData) <- unpackCallParameters call
+    return . packRLP $ rlpEncode ( nonce
+                                 , gasPrice
+                                 , gasLimit
+                                 , to
+                                 , value
+                                 , txData
+                                 , chainId
+                                 , 0 :: Integer
+                                 , 0 :: Integer
+                                 )
+
+
+createRawTransaction :: Call -> Integer -> ByteString -> Maybe Bytes
+createRawTransaction call chainId privateKey = do
+    rlpEndcoding <- rlpHashTransaction call chainId
+    let rlpHash = convert (hash rlpEndcoding :: Digest Keccak_256)
+    (nonce, gasPrice, gasLimit, to, value, txData) <- unpackCallParameters call
+    recSig <- ecsign rlpHash privateKey
+    let r = fromShort $ getCompactRecSigR recSig
+        s = fromShort $ getCompactRecSigS recSig
+        v = getCompactRecSigV recSig
+    return . convert . packRLP $
+        rlpEncode ( nonce
+                  , gasPrice
+                  , gasLimit
+                  , to
+                  , value
+                  , txData
+                  , fromIntegral v + 27 + chainId * 2 + 8
+                  , s -- swapping s & r, still don't know why
+                  , r
+                  )
+
+
+ecsign :: ByteString -> ByteString -> Maybe CompactRecSig
+ecsign msgHash privateKey = do
+    msgHash' <- msg msgHash
+    privateKey' <- secKey privateKey
+    return . exportCompactRecSig $ signRecMsg privateKey' msgHash'

--- a/src/Network/JsonRpc/TinyClient.hs
+++ b/src/Network/JsonRpc/TinyClient.hs
@@ -39,19 +39,19 @@ import           Control.Monad.Reader   (MonadReader, ask)
 import           Data.Aeson
 import           Data.ByteString.Lazy   (ByteString)
 import           Data.Text              (Text, unpack)
+import           Network.Ethereum.Web3.Provider
 import           Network.HTTP.Client    (Manager, RequestBody (RequestBodyLBS),
                                          httpLbs, method, parseRequest,
                                          requestBody, requestHeaders,
                                          responseBody)
 
+instance FromJSON a => Remote Web3 (Web3 a)
+
 -- | Name of called method.
 type MethodName = Text
 
--- | JSON-RPC server URI
-type ServerUri  = String
-
 -- | JSON-RPC minimal client config
-type Config = (ServerUri, Manager)
+type Config = (Provider, Manager)
 
 -- | JSON-RPC request.
 data Request = Request { rqMethod :: !Text
@@ -142,7 +142,7 @@ call :: (MonadIO m,
 call n = connection . encode . Request n 1 . toJSON
   where
     connection body = do
-        (uri, manager) <- ask
+        ((Provider (HttpProvider uri) _), manager) <- ask
         request <- parseRequest uri
         let request' = request
                      { requestBody = RequestBodyLBS body

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,10 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+    - relapse-1.0.0.0
+    - secp256k1-0.5.2
+
 # Override default flag values for local packages and extra-deps
 flags: {}
 # Extra package databases containing global packages

--- a/test/Network/Ethereum/Web3/Test/Utils.hs
+++ b/test/Network/Ethereum/Web3/Test/Utils.hs
@@ -26,8 +26,8 @@ import           Data.Traversable                  (for)
 
 import           Network.Ethereum.ABI.Prim.Address (Address)
 import           Network.Ethereum.Web3.Eth         (accounts, blockNumber)
-import           Network.Ethereum.Web3.Provider    (Provider (..), Web3,
-                                                    Web3Error, runWeb3')
+import           Network.Ethereum.Web3.Provider    (Provider (..), JsonRpcProvider(..)
+                                                   , Web3, Web3Error, runWeb3')
 import           Network.Ethereum.Web3.Types       (Call (..), Quantity)
 import           System.Environment                (lookupEnv, setEnv)
 import           Test.Hspec.Expectations           (shouldSatisfy)
@@ -63,14 +63,14 @@ injectExportedEnvironmentVariables = do
 
 runWeb3Configured :: Show a => Web3 a -> IO a
 runWeb3Configured f = do
-    provider <- HttpProvider <$> rpcUri
+    provider <- (flip Provider Nothing . HttpProvider) <$> rpcUri
     v <- runWeb3' provider f
     v `shouldSatisfy` isRight
     let Right a = v in return a
 
 runWeb3Configured' :: Web3 a -> IO a
 runWeb3Configured' f = do
-    provider <- HttpProvider <$> rpcUri
+    provider <- (flip Provider Nothing . HttpProvider) <$> rpcUri
     Right v <- runWeb3' provider f
     return v
 

--- a/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
+++ b/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Ethereum.Web3.Test.SignatureSpec where
+
+import           Data.ByteArray               (Bytes, convert)
+import qualified Data.ByteString.Base16       as BS16
+import qualified Data.Text                    as T
+import qualified Data.Text.Encoding           as T
+import           Network.Ethereum.Web3.Types
+import           Network.Ethereum.Web3.Transaction
+import           Test.Hspec
+
+
+-- using same example as in this blog post:
+-- https://medium.com/@codetractio/walkthrough-of-an-ethereum-improvement-proposal-eip-6fda3966d171
+spec :: Spec
+spec = describe "transaction signing" $
+    it "can create valid raw transaction" $ do
+        let rawTx = T.decodeUtf8 . BS16.encode . convert <$> createRawTransaction testCall 1 privKey
+        rawTx `shouldBe` (Just correctSignedTx)
+    where testCall = Call Nothing
+                          (Just "0x3535353535353535353535353535353535353535")
+                          (Just . Quantity $ 21000)
+                          (Just . Quantity $ 20000000000)
+                          (Just . Quantity $ 1000000000000000000)
+                          Nothing
+                          (Just 9)
+          privKey = fst . BS16.decode . T.encodeUtf8 $ "4646464646464646464646464646464646464646464646464646464646464646"
+          correctSignedTx = "f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83"

--- a/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
+++ b/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
@@ -3,7 +3,9 @@
 module Network.Ethereum.Web3.Test.SignatureSpec where
 
 import           Data.ByteArray               (Bytes, convert)
-import qualified Data.ByteString.Base16       as BS16
+import           Data.ByteArray.Encoding
+import           Data.ByteString              (ByteString)
+import           Data.Either                  (fromRight)
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           Network.Ethereum.Web3.Types
@@ -16,8 +18,8 @@ import           Test.Hspec
 spec :: Spec
 spec = describe "transaction signing" $
     it "can create valid raw transaction" $ do
-        let rawTx = T.decodeUtf8 . BS16.encode . convert <$> createRawTransaction testCall 1 privKey
-        rawTx `shouldBe` (Right correctSignedTx)
+        let rawTx = T.decodeUtf8 . convertToBase Base16 . (convert :: Bytes -> ByteString) <$> createRawTransaction testCall 1 privKey
+        rawTx `shouldBe` Right correctSignedTx
     where testCall = Call Nothing
                           (Just "0x3535353535353535353535353535353535353535")
                           (Just . Quantity $ 21000)
@@ -25,5 +27,5 @@ spec = describe "transaction signing" $
                           (Just . Quantity $ 1000000000000000000)
                           Nothing
                           (Just 9)
-          privKey = fst . BS16.decode . T.encodeUtf8 $ "4646464646464646464646464646464646464646464646464646464646464646"
+          privKey = fromRight (error "failed to encode private key") . convertFromBase Base16 . T.encodeUtf8 $ "4646464646464646464646464646464646464646464646464646464646464646"
           correctSignedTx = "f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83"

--- a/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
+++ b/unit/Network/Ethereum/Web3/Test/SignatureSpec.hs
@@ -17,7 +17,7 @@ spec :: Spec
 spec = describe "transaction signing" $
     it "can create valid raw transaction" $ do
         let rawTx = T.decodeUtf8 . BS16.encode . convert <$> createRawTransaction testCall 1 privKey
-        rawTx `shouldBe` (Just correctSignedTx)
+        rawTx `shouldBe` (Right correctSignedTx)
     where testCall = Call Nothing
                           (Just "0x3535353535353535353535353535353535353535")
                           (Just . Quantity $ 21000)

--- a/web3.cabal
+++ b/web3.cabal
@@ -107,8 +107,9 @@ test-suite unit
   hs-source-dirs:      unit
   main-is:             Spec.hs
   other-modules:       Network.Ethereum.Web3.Test.MethodDumpSpec
-                       Network.Ethereum.Web3.Test.EncodingSpec
-                       Network.Ethereum.Web3.Test.EventSpec
+                     , Network.Ethereum.Web3.Test.EncodingSpec
+                     , Network.Ethereum.Web3.Test.EventSpec
+                     , Network.Ethereum.Web3.Test.SignatureSpec
   build-depends:       base                 >4.9       && <4.12
                      , base16-bytestring    >=0.1.1.6  && <0.2
                      , hspec-expectations   >=0.8.2    && <0.9

--- a/web3.cabal
+++ b/web3.cabal
@@ -72,7 +72,6 @@ library
                      , http-client          >=0.5.12.1 && <0.6
                      , exceptions           >=0.8.3    && <0.9
                      , bytestring           >=0.10.8.2 && <0.11
-                     , base16-bytestring    >=0.1.1.6  && <0.2
                      , cryptonite           ==0.25.*
                      , basement             >=0.0.7    && <0.1
                      , machines             >=0.6.3    && <0.7
@@ -111,7 +110,6 @@ test-suite unit
                      , Network.Ethereum.Web3.Test.EventSpec
                      , Network.Ethereum.Web3.Test.SignatureSpec
   build-depends:       base                 >4.9       && <4.12
-                     , base16-bytestring    >=0.1.1.6  && <0.2
                      , hspec-expectations   >=0.8.2    && <0.9
                      , hspec-discover       >=2.4.8    && <2.6
                      , hspec-contrib        >=0.4.0    && <0.6

--- a/web3.cabal
+++ b/web3.cabal
@@ -42,6 +42,7 @@ library
                      , Network.Ethereum.Web3.Web3
                      , Network.Ethereum.Web3.Types
                      , Network.Ethereum.Web3.Provider
+                     , Network.Ethereum.Web3.Transaction
                      , Network.Ethereum.Unit
                      , Network.Ethereum.ABI.Json
                      , Network.Ethereum.ABI.Class
@@ -71,6 +72,7 @@ library
                      , http-client          >=0.5.12.1 && <0.6
                      , exceptions           >=0.8.3    && <0.9
                      , bytestring           >=0.10.8.2 && <0.11
+                     , base16-bytestring    >=0.1.1.6  && <0.2
                      , cryptonite           ==0.25.*
                      , basement             >=0.0.7    && <0.1
                      , machines             >=0.6.3    && <0.7
@@ -80,6 +82,8 @@ library
                      , cereal               >=0.5.5.0  && <0.6
                      , aeson                >=1.2.4.0  && <1.3
                      , async                >=2.1.1.1  && <2.3
+                     , relapse              ==1.0.0.0
+                     , secp256k1            >=0.5.2    && <0.6
                      , text                 >=1.2.3.0  && <1.3
                      , mtl                  >=2.2.2    && <2.3
 

--- a/web3.cabal
+++ b/web3.cabal
@@ -110,6 +110,7 @@ test-suite unit
                        Network.Ethereum.Web3.Test.EncodingSpec
                        Network.Ethereum.Web3.Test.EventSpec
   build-depends:       base                 >4.9       && <4.12
+                     , base16-bytestring    >=0.1.1.6  && <0.2
                      , hspec-expectations   >=0.8.2    && <0.9
                      , hspec-discover       >=2.4.8    && <2.6
                      , hspec-contrib        >=0.4.0    && <0.6


### PR DESCRIPTION
Resolves #10.

- Signing configuration requires supplying both a __private key__ and a __chainId__. The chainId will be different depending on what network a user is submitting transactions to (mainnet, Rinkby, etc.)

```haskell
-- | Web3 Provider
data Provider = Provider { jsonRpc :: JsonRpcProvider
                         , signingConfiguration :: Maybe SigningConfiguration
                         }

data SigningConfiguration = SigningConfiguration { privateKey      :: ByteString
                                                 , chainIdentifier :: Integer }
```

- The `Web3` type has been updated to have the full `Provider` type in its Reader context so that the private key and chain identifier can be used when signing transactions.

```haskell
newtype Web3 a = Web3 { unWeb3 :: ReaderT (Provider, Manager) IO a }
```