### PR TITLE
Zero-pad sized-bytes literals

### DIFF
--- a/src/Network/Ethereum/ABI/Prim/Bytes.hs
+++ b/src/Network/Ethereum/ABI/Prim/Bytes.hs
@@ -95,7 +95,10 @@ instance (KnownNat n, n <= 32) => ABIPut (BytesN n) where
       where len = fromIntegral $ natVal (Proxy :: Proxy n)
 
 instance (KnownNat n, n <= 32) => IsString (BytesN n) where
-    fromString = unsafeFromByteArrayAccess . (fromString :: String -> Bytes)
+    fromString s = unsafeFromByteArrayAccess padded
+      where bytes = fromString s :: Bytes
+            len = fromIntegral $ natVal (Proxy :: Proxy n)
+            padded = bytes <> zero (len - length bytes)
 
 instance (KnownNat n, n <= 32) => FromJSON (BytesN n) where
     parseJSON v = do ba <- parseJSON v

--- a/unit/Network/Ethereum/Web3/Test/EncodingSpec.hs
+++ b/unit/Network/Ethereum/Web3/Test/EncodingSpec.hs
@@ -6,6 +6,7 @@
 
 module Network.Ethereum.Web3.Test.EncodingSpec where
 
+import           Control.Exception                (evaluate)
 import           Data.Monoid                      ((<>))
 import           Data.Text                        (Text)
 import           Generics.SOP                     (Generic, Rep)
@@ -84,6 +85,20 @@ bytesNTest =
          let decoded = "0x6761766f66796f726b000000" :: BytesN 12
              encoded = "0x6761766f66796f726b0000000000000000000000000000000000000000000000"
          roundTrip decoded encoded
+
+      it "can pad shorter hex-literals" $ do
+         let literal = "0xc3a4" :: BytesN 4
+             expected = "0xc3a40000" :: BytesN 4
+         literal `shouldBe` expected
+
+      it "can pad shorter string-literals" $ do
+         let literal = "hello" :: BytesN 8
+             expected = "0x68656c6c6f000000" :: BytesN 8
+         literal `shouldBe` expected
+
+      it "fails on too long literals" $ do
+         let literal = "hello" :: BytesN 4
+         evaluate literal `shouldThrow` errorCall "Invalid Size"
 
 vectorTest :: Spec
 vectorTest =


### PR DESCRIPTION
Using the `IsString` instance of `BytesN n` can cause an error if the provided string literal is too short, or too long. Especially for string-literals such as `"ETH" :: BytesN 8`, this behaviour is not very user friendly.

With this change too short literals are zero padded to the right. If the literal is too long, the previous 
 behaviour is preserved, and an error is thrown.