### PR TITLE
Drop leading underscores in data definitions

### DIFF
--- a/src/Network/Ethereum/Contract/TH.hs
+++ b/src/Network/Ethereum/Contract/TH.hs
@@ -213,7 +213,7 @@ mkDecl fun@(DFunction name constant inputs outputs) = (++)
           [funD' 'selector [] [|const mIdent|]]
         ]
   where mIdent    = T.unpack (methodId $ fun {funName = T.replace "'" "" name})
-        dataName  = mkName (toUpperFirst (T.unpack $ name <> "Data"))
+        dataName  = mkName (toUpperFirst (T.unpack $ T.dropWhile (== '_') name <> "Data"))
         fnName    = mkName (toLowerFirst (T.unpack name))
         bangInput = fmap funBangType inputs
         derivingD = [''Show, ''Eq, ''Ord, ''GHC.Generic]


### PR DESCRIPTION
These cause errors of the form

    Illegal data constructor name: ‘_fooData’
    When splicing a TH declaration: