### PR TITLE
Encoding of empty bytes

### DIFF
--- a/src/Network/Ethereum/ABI/Prim/Bytes.hs
+++ b/src/Network/Ethereum/ABI/Prim/Bytes.hs
@@ -23,6 +23,7 @@ module Network.Ethereum.ABI.Prim.Bytes (
   , BytesN
   ) where
 
+import           Control.Monad                 (unless)
 import           Data.Aeson                    (FromJSON (..), ToJSON (..),
                                                 Value (String))
 import           Data.ByteArray                (Bytes, convert, length, zero)
@@ -110,12 +111,16 @@ instance (KnownNat n, n <= 32) => ToJSON (BytesN n) where
 abiGetByteString :: Get ByteString
 abiGetByteString = do
     len <- fromIntegral <$> getWord256
-    ba <- getBytes len
-    _ <- getBytes $ 32 - len `mod` 32
-    return ba
+    if len == 0 then
+      return ""
+    else do
+      ba <- getBytes len
+      _ <- getBytes $ 32 - len `mod` 32
+      return ba
 
 abiPutByteString :: Putter ByteString
 abiPutByteString bs = do
     putWord256 $ fromIntegral len
-    putByteString $ bs <> zero (32 - len `mod` 32)
+    unless (len == 0) $
+      putByteString $ bs <> zero (32 - len `mod` 32)
   where len = length bs

--- a/unit/Network/Ethereum/Web3/Test/EncodingSpec.hs
+++ b/unit/Network/Ethereum/Web3/Test/EncodingSpec.hs
@@ -54,6 +54,12 @@ bytesTest :: Spec
 bytesTest = do
     describe "bytes tests" $ do
 
+      it "can encode empty bytes" $ do
+         let decoded :: Bytes
+             decoded = "0x"
+             encoded = "0x0000000000000000000000000000000000000000000000000000000000000000"
+          in roundTrip decoded encoded
+
       it "can encode short bytes" $ do
          let decoded :: Bytes
              decoded = "0xc3a40000c3a4"


### PR DESCRIPTION
The [solidity specification][spec] says about the encoding of bytes (emphasis mine):

> `enc(X) = enc(k) pad_right(X)`, i.e. the number of bytes is encoded as a `uint256` followed by the actual value of `X` as a byte sequence, followed by the **minimum number of zero-bytes** such that `len(enc(X))` is a multiple of 32.

Previously, an empty bytes value would be encoded as 64 zero bytes, however, as I understand the specification, the proper encoding should be 32 zero bytes. I.e. only the 32 zero bytes for the length.

[spec]: https://solidity.readthedocs.io/en/develop/abi-spec.html#application-binary-interface-specification

Specifically, I encountered an event decoding failure on a `Transfer` event with an empty `data` field from an [ERC223 interface]( https://github.com/Dexaran/ERC223-token-standard/blob/c3c00899d61f613adfed6a4e0a658a7286169218/token/ERC223/ERC223_interface.sol) on Parity v1.9.5. The suggested change fixed that decoding failure.