### PR TITLE
Added runWeb3WS and included websockets in dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
 - async                >=2.1.1.1  && <2.3
 - text                 >=1.2.2.2  && <1.3
 - mtl                  >=2.2.1    && <2.3
+- websockets           >=0.12.5.3 && <0.13
 
 ghc-options:
 - -funbox-strict-fields

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
 - text                 >=1.2.2.2  && <1.3
 - mtl                  >=2.2.1    && <2.3
 - websockets           >=0.12.5.3 && <0.13
+- network              >=2.8.0.1  && <2.9
 
 ghc-options:
 - -funbox-strict-fields

--- a/src/Network/Ethereum/Api/Provider.hs
+++ b/src/Network/Ethereum/Api/Provider.hs
@@ -22,9 +22,8 @@ import           Control.Exception          (Exception, try)
 import           Control.Monad.Catch        (MonadThrow)
 import           Control.Monad.IO.Class     (MonadIO (..))
 import           Control.Monad.State        (MonadState (..))
-import           Control.Monad.Trans.State  (StateT, evalStateT)
+import           Control.Monad.Trans.State  (StateT, evalStateT, withStateT)
 import           GHC.Generics               (Generic)
-import           Lens.Micro.Mtl             ((.=))
 import           Network.HTTP.Client        (Manager)
 
 import           Network.JsonRpc.TinyClient (JsonRpc, JsonRpcClient,
@@ -62,8 +61,10 @@ runWeb3With :: MonadIO m
             -> Provider
             -> Web3 a
             -> m (Either Web3Error a)
-runWeb3With manager provider f =
-    runWeb3' provider $ jsonRpcManager .= manager >> f
+runWeb3With manager provider f = do  
+    runWeb3' provider Web3{ unWeb3 = withStateT changeManager $ unWeb3 f}
+    where
+      changeManager jsonRpc = jsonRpc {jsonRpcManager = manager} 
 
 -- | 'Web3' monad runner
 runWeb3' :: MonadIO m

--- a/src/Network/Ethereum/Api/Provider.hs
+++ b/src/Network/Ethereum/Api/Provider.hs
@@ -25,8 +25,13 @@ import           Control.Monad.State        (MonadState (..))
 import           Control.Monad.Trans.State  (StateT, evalStateT, withStateT)
 import           GHC.Generics               (Generic)
 import           Network.HTTP.Client        (Manager)
+import qualified Network.Socket             as S
+import qualified Network.WebSockets.Stream  as Stream
+import qualified Network.WebSockets         as WS ( Connection, 
+                                                    newClientConnection, 
+                                                    defaultConnectionOptions)
 
-import           Network.JsonRpc.TinyClient (JsonRpc, JsonRpcClient,
+import           Network.JsonRpc.TinyClient (JsonRpc, JsonRpcClient(..),
                                              defaultSettings, jsonRpcManager)
 
 -- | Any communication with Ethereum node wrapped with 'Web3' monad
@@ -49,11 +54,14 @@ instance Exception Web3Error
 
 --TODO: Change to `HttpProvider ServerUri | IpcProvider FilePath` to support IPC
 -- | Web3 Provider
-data Provider = HttpProvider String | WSProvider String
+data Provider = HttpProvider String | WSProvider String Int
   deriving (Show, Eq, Generic)
 
-defaultHttpPovider = HttpProvider "http://localhost:8545"
-defaultWSPovider   = WSProvider   "ws://127.0.0.1:8546"
+defaultHttpPovider :: Provider
+defaultHttpPovider = HttpProvider "http://localhost:8545" -- | Default HTTP Provider URI
+
+defaultWSPovider   :: Provider
+defaultWSPovider   = WSProvider   "127.0.0.1" 8546        -- | Default WS Provider URI 
 
 -- | 'Web3' monad runner, using the supplied Manager
 runWeb3With :: MonadIO m
@@ -66,7 +74,7 @@ runWeb3With manager provider f = do
     where
       changeManager jsonRpc = jsonRpc {jsonRpcManager = manager} 
 
--- | 'Web3' monad runner
+-- | 'Web3' monad runner for http
 runWeb3' :: MonadIO m
          => Provider
          -> Web3 a
@@ -74,6 +82,14 @@ runWeb3' :: MonadIO m
 runWeb3' (HttpProvider uri) f = do
     cfg <- defaultSettings uri
     liftIO . try . flip evalStateT cfg . unWeb3 $ f
+
+runWeb3' (WSProvider host port) f = do
+    currentConnection <- liftIO $ getConnection host port "/"
+    let currentClient = JsonRpcWSClient { 
+          jsonRpcWSConn = currentConnection
+        , jsonRpcWSHost = host
+        , jsonRpcWSPort = port}
+    liftIO . try . flip evalStateT currentClient . unWeb3 $ f
 
 -- | 'Web3' runner for default http provider
 runWeb3 :: MonadIO m
@@ -84,11 +100,40 @@ runWeb3 = runWeb3' defaultHttpPovider
 
 -- | 'Web3' runner for default WS provider
 runWeb3WS :: MonadIO m
-        => Web3 a
-        -> m (Either Web3Error a)
+          => Web3 a
+          -> m (Either Web3Error a)
 {-# INLINE runWeb3WS #-}
 runWeb3WS = runWeb3' defaultWSPovider
 
 -- | Fork 'Web3' with the same 'Provider' and 'Manager'
 forkWeb3 :: Web3 a -> Web3 (Async a)
 forkWeb3 f = liftIO . async . evalStateT (unWeb3 f) =<< get
+
+getConnection :: (Eq a, Num a, Show a)
+              => S.HostName
+              -> a
+              -> [Char]
+              -> IO WS.Connection
+{-# INLINE getConnection #-}
+getConnection host port path = do
+    -- Create and connect socket
+    let hints = S.defaultHints
+                    {S.addrSocketType = S.Stream}
+        
+        -- Correct host and path.
+        fullHost = if port == 80 then host else (host ++ ":" ++ show port)
+        path0     = if null path then "/" else path
+
+    addr:_ <- S.getAddrInfo (Just hints) (Just host) (Just $ show port)
+    sock      <- S.socket (S.addrFamily addr) S.Stream S.defaultProtocol
+    S.setSocketOption sock S.NoDelay 1
+
+    -- Connect WebSocket and run client
+     
+    res <-  ( S.connect sock (S.addrAddress addr) >>
+            Stream.makeSocketStream sock) >>=
+              (\stream ->
+                    WS.newClientConnection stream fullHost 
+                    path0 WS.defaultConnectionOptions [] )     
+    -- Clean up
+    return res

--- a/src/Network/JsonRpc/TinyClient.hs
+++ b/src/Network/JsonRpc/TinyClient.hs
@@ -85,12 +85,12 @@ type JsonRpcM m = (MonadIO m, MonadThrow m, MonadState JsonRpcClient m)
 
 -- | JSON-RPC client state vars.
 data JsonRpcClient = JsonRpcHTTPClient
-    { jsonRpcManager  :: Manager    -- ^ HTTP connection manager.
-    , jsonRpcServer   :: String     -- ^ Remote server URI.
+    { jsonRpcManager  :: Manager        -- ^ HTTP connection manager.
+    , jsonRpcServer   :: String         -- ^ Remote server URI.
     }              | JsonRpcWSClient
-    { jsonRpcWSConn   :: WS.Connection -- ^ WS connection.
-    , jsonRpcWSHost   :: String     -- ^ Remote Host.
-    , jsonRpcWSPort   :: Int        -- ^ Port
+    { jsonRpcWSConn   :: WS.Connection  -- ^ WS connection.
+    , jsonRpcWSHost   :: String         -- ^ Remote Host.
+    , jsonRpcWSPort   :: Int            -- ^ Port
     }                 
 
 -- | Create default 'JsonRpcClient' settings.


### PR DESCRIPTION
runWeb3WS is the web3 runner for default WebSocket Provider at 'ws://127.0.0.1:8546'.

**Tasks Completed:**

**(in Network.JsonRpc.TinyClient) :** 
- Extending JsonRpcClient to hold a WebSocket Connection.
- Pattern matching in connection function and implementing the code for WebSocket connection.

**(in Network.Ethereum.Api.Provider) :** 
- Updating runWeb3With function by replacing .= of microlens-mtl by State Monad Functions
- Pattern matching in runWeb3' function and implementing the code for WebSocket connection.
- Adding the getConnection function, which returns a WebSocket connection data type.
- Adding WS.sendClose function to close WebSocket Connection.

[**Work Folder**](https://drive.google.com/open?id=1kYqnOpvd0zDfBd262Em98KcJi55t9AOq) Contains :- 
- WS API Analysis Document.
- Example codes and Output Screenshots of Using websockets library with Geth or Parity.
- Example codes and Output Screenshots of getConnection and runWeb3WS functions respectively.
- The codes also include the Required Geth and Parity Specifications.

**Other Tasks Completed:**
- Created Multiple Example Codes on Running WS API of Geth/Parity using the websockets Library.
- Example code of the getConnection and the runWeb3WS functions respectively.
- Analysis of hs-web3 Library Code.
- Analysis of WebSockets Library Code.
- Analysis of mtl library (focusing on MonadState), MTL Lenses (micorlens-mtl) and Aeson (used for encoding and decoding of JSON RPC Requests and Responses respectively).