### PR TITLE
Tuple support for `pragma experimental ABIEncoderV2`

### DIFF
--- a/test/contracts/Exchange.json
+++ b/test/contracts/Exchange.json
@@ -1,0 +1,1059 @@
+{
+    "schemaVersion": "2.0.0",
+    "contractName": "Exchange",
+    "compilerOutput": {
+        "abi": [
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "bytes32" }],
+                "name": "filled",
+                "outputs": [{ "name": "", "type": "uint256" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "takerAssetFillAmounts", "type": "uint256[]" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "batchFillOrders",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "bytes32" }],
+                "name": "cancelled",
+                "outputs": [{ "name": "", "type": "bool" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    { "name": "hash", "type": "bytes32" },
+                    { "name": "signerAddress", "type": "address" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "preSign",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "leftOrder",
+                        "type": "tuple"
+                    },
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "rightOrder",
+                        "type": "tuple"
+                    },
+                    { "name": "leftSignature", "type": "bytes" },
+                    { "name": "rightSignature", "type": "bytes" }
+                ],
+                "name": "matchOrders",
+                "outputs": [
+                    {
+                        "components": [
+                            {
+                                "components": [
+                                    { "name": "makerAssetFilledAmount", "type": "uint256" },
+                                    { "name": "takerAssetFilledAmount", "type": "uint256" },
+                                    { "name": "makerFeePaid", "type": "uint256" },
+                                    { "name": "takerFeePaid", "type": "uint256" }
+                                ],
+                                "name": "left",
+                                "type": "tuple"
+                            },
+                            {
+                                "components": [
+                                    { "name": "makerAssetFilledAmount", "type": "uint256" },
+                                    { "name": "takerAssetFilledAmount", "type": "uint256" },
+                                    { "name": "makerFeePaid", "type": "uint256" },
+                                    { "name": "takerFeePaid", "type": "uint256" }
+                                ],
+                                "name": "right",
+                                "type": "tuple"
+                            },
+                            { "name": "leftMakerAssetSpreadAmount", "type": "uint256" }
+                        ],
+                        "name": "matchedFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "order",
+                        "type": "tuple"
+                    },
+                    { "name": "takerAssetFillAmount", "type": "uint256" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "fillOrderNoThrow",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "fillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "bytes4" }],
+                "name": "assetProxies",
+                "outputs": [{ "name": "", "type": "address" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    }
+                ],
+                "name": "batchCancelOrders",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "takerAssetFillAmounts", "type": "uint256[]" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "batchFillOrKillOrders",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [{ "name": "targetOrderEpoch", "type": "uint256" }],
+                "name": "cancelOrdersUpTo",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "takerAssetFillAmounts", "type": "uint256[]" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "batchFillOrdersNoThrow",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "assetProxyId", "type": "bytes4" }],
+                "name": "getAssetProxy",
+                "outputs": [{ "name": "", "type": "address" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "bytes32" }],
+                "name": "transactions",
+                "outputs": [{ "name": "", "type": "bool" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "order",
+                        "type": "tuple"
+                    },
+                    { "name": "takerAssetFillAmount", "type": "uint256" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "fillOrKillOrder",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "fillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [{ "name": "validatorAddress", "type": "address" }, { "name": "approval", "type": "bool" }],
+                "name": "setSignatureValidatorApproval",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "address" }, { "name": "", "type": "address" }],
+                "name": "allowedValidators",
+                "outputs": [{ "name": "", "type": "bool" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "takerAssetFillAmount", "type": "uint256" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "marketSellOrders",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    }
+                ],
+                "name": "getOrdersInfo",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "orderStatus", "type": "uint8" },
+                            { "name": "orderHash", "type": "bytes32" },
+                            { "name": "orderTakerAssetFilledAmount", "type": "uint256" }
+                        ],
+                        "name": "",
+                        "type": "tuple[]"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "bytes32" }, { "name": "", "type": "address" }],
+                "name": "preSigned",
+                "outputs": [{ "name": "", "type": "bool" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "owner",
+                "outputs": [{ "name": "", "type": "address" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    { "name": "hash", "type": "bytes32" },
+                    { "name": "signerAddress", "type": "address" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "isValidSignature",
+                "outputs": [{ "name": "isValid", "type": "bool" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "makerAssetFillAmount", "type": "uint256" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "marketBuyOrdersNoThrow",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "order",
+                        "type": "tuple"
+                    },
+                    { "name": "takerAssetFillAmount", "type": "uint256" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "fillOrder",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "fillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    { "name": "salt", "type": "uint256" },
+                    { "name": "signerAddress", "type": "address" },
+                    { "name": "data", "type": "bytes" },
+                    { "name": "signature", "type": "bytes" }
+                ],
+                "name": "executeTransaction",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [{ "name": "assetProxy", "type": "address" }],
+                "name": "registerAssetProxy",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "order",
+                        "type": "tuple"
+                    }
+                ],
+                "name": "getOrderInfo",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "orderStatus", "type": "uint8" },
+                            { "name": "orderHash", "type": "bytes32" },
+                            { "name": "orderTakerAssetFilledAmount", "type": "uint256" }
+                        ],
+                        "name": "orderInfo",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "order",
+                        "type": "tuple"
+                    }
+                ],
+                "name": "cancelOrder",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [{ "name": "", "type": "address" }, { "name": "", "type": "address" }],
+                "name": "orderEpoch",
+                "outputs": [{ "name": "", "type": "uint256" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "ZRX_ASSET_DATA",
+                "outputs": [{ "name": "", "type": "bytes" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "takerAssetFillAmount", "type": "uint256" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "marketSellOrdersNoThrow",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "EIP712_DOMAIN_HASH",
+                "outputs": [{ "name": "", "type": "bytes32" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "components": [
+                            { "name": "makerAddress", "type": "address" },
+                            { "name": "takerAddress", "type": "address" },
+                            { "name": "feeRecipientAddress", "type": "address" },
+                            { "name": "senderAddress", "type": "address" },
+                            { "name": "makerAssetAmount", "type": "uint256" },
+                            { "name": "takerAssetAmount", "type": "uint256" },
+                            { "name": "makerFee", "type": "uint256" },
+                            { "name": "takerFee", "type": "uint256" },
+                            { "name": "expirationTimeSeconds", "type": "uint256" },
+                            { "name": "salt", "type": "uint256" },
+                            { "name": "makerAssetData", "type": "bytes" },
+                            { "name": "takerAssetData", "type": "bytes" }
+                        ],
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    { "name": "makerAssetFillAmount", "type": "uint256" },
+                    { "name": "signatures", "type": "bytes[]" }
+                ],
+                "name": "marketBuyOrders",
+                "outputs": [
+                    {
+                        "components": [
+                            { "name": "makerAssetFilledAmount", "type": "uint256" },
+                            { "name": "takerAssetFilledAmount", "type": "uint256" },
+                            { "name": "makerFeePaid", "type": "uint256" },
+                            { "name": "takerFeePaid", "type": "uint256" }
+                        ],
+                        "name": "totalFillResults",
+                        "type": "tuple"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "currentContextAddress",
+                "outputs": [{ "name": "", "type": "address" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [{ "name": "newOwner", "type": "address" }],
+                "name": "transferOwnership",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "VERSION",
+                "outputs": [{ "name": "", "type": "string" }],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [{ "name": "_zrxAssetData", "type": "bytes" }],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    { "indexed": true, "name": "signerAddress", "type": "address" },
+                    { "indexed": true, "name": "validatorAddress", "type": "address" },
+                    { "indexed": false, "name": "approved", "type": "bool" }
+                ],
+                "name": "SignatureValidatorApproval",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    { "indexed": true, "name": "makerAddress", "type": "address" },
+                    { "indexed": true, "name": "feeRecipientAddress", "type": "address" },
+                    { "indexed": false, "name": "takerAddress", "type": "address" },
+                    { "indexed": false, "name": "senderAddress", "type": "address" },
+                    { "indexed": false, "name": "makerAssetFilledAmount", "type": "uint256" },
+                    { "indexed": false, "name": "takerAssetFilledAmount", "type": "uint256" },
+                    { "indexed": false, "name": "makerFeePaid", "type": "uint256" },
+                    { "indexed": false, "name": "takerFeePaid", "type": "uint256" },
+                    { "indexed": true, "name": "orderHash", "type": "bytes32" },
+                    { "indexed": false, "name": "makerAssetData", "type": "bytes" },
+                    { "indexed": false, "name": "takerAssetData", "type": "bytes" }
+                ],
+                "name": "Fill",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    { "indexed": true, "name": "makerAddress", "type": "address" },
+                    { "indexed": true, "name": "feeRecipientAddress", "type": "address" },
+                    { "indexed": false, "name": "senderAddress", "type": "address" },
+                    { "indexed": true, "name": "orderHash", "type": "bytes32" },
+                    { "indexed": false, "name": "makerAssetData", "type": "bytes" },
+                    { "indexed": false, "name": "takerAssetData", "type": "bytes" }
+                ],
+                "name": "Cancel",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    { "indexed": true, "name": "makerAddress", "type": "address" },
+                    { "indexed": true, "name": "senderAddress", "type": "address" },
+                    { "indexed": false, "name": "orderEpoch", "type": "uint256" }
+                ],
+                "name": "CancelUpTo",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    { "indexed": false, "name": "id", "type": "bytes4" },
+                    { "indexed": false, "name": "assetProxy", "type": "address" }
+                ],
+                "name": "AssetProxyRegistered",
+                "type": "event"
+            }
+        ],
+        "devdoc": {
+            "methods": {
+                "batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])": {
+                    "details": "Synchronously cancels multiple orders in a single transaction.",
+                    "params": { "orders": "Array of order specifications." }
+                },
+                "batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])": {
+                    "details": "Synchronously executes multiple calls of fillOrKill.",
+                    "params": {
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been created by makers.",
+                        "takerAssetFillAmounts": "Array of desired amounts of takerAsset to sell in orders."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker.         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets."
+                },
+                "batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])": {
+                    "details": "Synchronously executes multiple calls of fillOrder.",
+                    "params": {
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been created by makers.",
+                        "takerAssetFillAmounts": "Array of desired amounts of takerAsset to sell in orders."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker.         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets."
+                },
+                "batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])": {
+                    "details": "Fills an order with specified parameters and ECDSA signature.      Returns false if the transaction would otherwise revert.",
+                    "params": {
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been created by makers.",
+                        "takerAssetFillAmounts": "Array of desired amounts of takerAsset to sell in orders."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker.         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets."
+                },
+                "cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))": {
+                    "details": "After calling, the order can not be filled anymore.      Throws if order is invalid or sender does not have permission to cancel.",
+                    "params": { "order": "Order to cancel. Order must be OrderStatus.FILLABLE." }
+                },
+                "cancelOrdersUpTo(uint256)": {
+                    "details": "Cancels all orders created by makerAddress with a salt less than or equal to the targetOrderEpoch      and senderAddress equal to msg.sender (or null address if msg.sender == makerAddress).",
+                    "params": {
+                        "targetOrderEpoch": "Orders created with a salt less or equal to this value will be cancelled."
+                    }
+                },
+                "executeTransaction(uint256,address,bytes,bytes)": {
+                    "details": "Executes an exchange method call in the context of signer.",
+                    "params": {
+                        "data": "AbiV2 encoded calldata.",
+                        "salt": "Arbitrary number to ensure uniqueness of transaction hash.",
+                        "signature": "Proof of signer transaction by signer.",
+                        "signerAddress": "Address of transaction signer."
+                    }
+                },
+                "fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)": {
+                    "details": "Fills the input order. Reverts if exact takerAssetFillAmount not filled.",
+                    "params": {
+                        "order": "Order struct containing order specifications.",
+                        "signature": "Proof that order has been created by maker.",
+                        "takerAssetFillAmount": "Desired amount of takerAsset to sell."
+                    }
+                },
+                "fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)": {
+                    "details": "Fills the input order.",
+                    "params": {
+                        "order": "Order struct containing order specifications.",
+                        "signature": "Proof that order has been created by maker.",
+                        "takerAssetFillAmount": "Desired amount of takerAsset to sell."
+                    },
+                    "return": "Amounts filled and fees paid by maker and taker."
+                },
+                "fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)": {
+                    "details": "Fills the input order.      Returns false if the transaction would otherwise revert.",
+                    "params": {
+                        "order": "Order struct containing order specifications.",
+                        "signature": "Proof that order has been created by maker.",
+                        "takerAssetFillAmount": "Desired amount of takerAsset to sell."
+                    },
+                    "return": "Amounts filled and fees paid by maker and taker."
+                },
+                "getAssetProxy(bytes4)": {
+                    "details": "Gets an asset proxy.",
+                    "params": { "assetProxyId": "Id of the asset proxy." },
+                    "return": "The asset proxy registered to assetProxyId. Returns 0x0 if no proxy is registered."
+                },
+                "getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))": {
+                    "details": "Gets information about an order: status, hash, and amount filled.",
+                    "params": { "order": "Order to gather information on." },
+                    "return": "OrderInfo Information about the order and its state.         See LibOrder.OrderInfo for a complete description."
+                },
+                "getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])": {
+                    "details": "Fetches information for all passed in orders.",
+                    "params": { "orders": "Array of order specifications." },
+                    "return": "Array of OrderInfo instances that correspond to each order."
+                },
+                "isValidSignature(bytes32,address,bytes)": {
+                    "details": "Verifies that a hash has been signed by the given signer.",
+                    "params": {
+                        "hash": "Any 32 byte hash.",
+                        "signature": "Proof that the hash has been signed by signer.",
+                        "signerAddress": "Address that should have signed the given hash."
+                    },
+                    "return": "True if the address recovered from the provided signature matches the input signer address."
+                },
+                "marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])": {
+                    "details": "Synchronously executes multiple calls of fillOrder until total amount of makerAsset is bought by taker.",
+                    "params": {
+                        "makerAssetFillAmount": "Desired amount of makerAsset to buy.",
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been signed by makers."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker."
+                },
+                "marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])": {
+                    "details": "Synchronously executes multiple fill orders in a single transaction until total amount is bought by taker.      Returns false if the transaction would otherwise revert.",
+                    "params": {
+                        "makerAssetFillAmount": "Desired amount of makerAsset to buy.",
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been signed by makers."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker."
+                },
+                "marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])": {
+                    "details": "Synchronously executes multiple calls of fillOrder until total amount of takerAsset is sold by taker.",
+                    "params": {
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been created by makers.",
+                        "takerAssetFillAmount": "Desired amount of takerAsset to sell."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker."
+                },
+                "marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])": {
+                    "details": "Synchronously executes multiple calls of fillOrder until total amount of takerAsset is sold by taker.      Returns false if the transaction would otherwise revert.",
+                    "params": {
+                        "orders": "Array of order specifications.",
+                        "signatures": "Proofs that orders have been signed by makers.",
+                        "takerAssetFillAmount": "Desired amount of takerAsset to sell."
+                    },
+                    "return": "Amounts filled and fees paid by makers and taker."
+                },
+                "matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)": {
+                    "details": "Match two complementary orders that have a profitable spread.      Each order is filled at their respective price point. However, the calculations are      carried out as though the orders are both being filled at the right order's price point.      The profit made by the left order goes to the taker (who matched the two orders).",
+                    "params": {
+                        "leftOrder": "First order to match.",
+                        "leftSignature": "Proof that order was created by the left maker.",
+                        "rightOrder": "Second order to match.",
+                        "rightSignature": "Proof that order was created by the right maker."
+                    },
+                    "return": "matchedFillResults Amounts filled and fees paid by maker and taker of matched orders."
+                },
+                "preSign(bytes32,address,bytes)": {
+                    "details": "Approves a hash on-chain using any valid signature type.      After presigning a hash, the preSign signature type will become valid for that hash and signer.",
+                    "params": {
+                        "signature": "Proof that the hash has been signed by signer.",
+                        "signerAddress": "Address that should have signed the given hash."
+                    }
+                },
+                "registerAssetProxy(address)": {
+                    "details": "Registers an asset proxy to its asset proxy id.      Once an asset proxy is registered, it cannot be unregistered.",
+                    "params": { "assetProxy": "Address of new asset proxy to register." }
+                },
+                "setSignatureValidatorApproval(address,bool)": {
+                    "details": "Approves/unnapproves a Validator contract to verify signatures on signer's behalf.",
+                    "params": {
+                        "approval": "Approval or disapproval of  Validator contract.",
+                        "validatorAddress": "Address of Validator contract."
+                    }
+                }
+            }
+        },
+        "evm": {
+            "bytecode": {
+                "object": "0x60806040526000805460ff191690553480156200001b57600080fd5b5060405162005ec038038062005ec083398101806040526200004191908101906200044d565b80518190620000589060019060208401906200034c565b5050604080517f454950373132446f6d61696e28000000000000000000000000000000000000006020808301919091527f737472696e67206e616d652c0000000000000000000000000000000000000000602d8301527f737472696e672076657273696f6e2c000000000000000000000000000000000060398301527f6164647265737320766572696679696e67436f6e74726163740000000000000060488301527f2900000000000000000000000000000000000000000000000000000000000000606183015282516042818403018152606290920192839052815191929182918401908083835b60208310620001625780518252601f19909201916020918201910162000141565b51815160209384036101000a6000190180199092169116179052604080519290940182900382208285018552600b8084527f30782050726f746f636f6c000000000000000000000000000000000000000000928401928352945190965091945090928392508083835b60208310620001ec5780518252601f199092019160209182019101620001cb565b51815160209384036101000a600019018019909216911617905260408051929094018290038220828501855260018084527f3200000000000000000000000000000000000000000000000000000000000000928401928352945190965091945090928392508083835b60208310620002765780518252601f19909201916020918201910162000255565b51815160209384036101000a6000190180199092169116179052604080519290940182900382208282019890985281840196909652606081019690965250306080808701919091528151808703909101815260a09095019081905284519093849350850191508083835b60208310620003015780518252601f199092019160209182019101620002e0565b5181516000196020949094036101000a939093019283169219169190911790526040519201829003909120600255505060038054600160a060020a03191633179055506200050f9050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106200038f57805160ff1916838001178555620003bf565b82800160010185558215620003bf579182015b82811115620003bf578251825591602001919060010190620003a2565b50620003cd929150620003d1565b5090565b620003ee91905b80821115620003cd5760008155600101620003d8565b90565b6000601f820183136200040357600080fd5b81516200041a6200041482620004b4565b6200048d565b915080825260208301602083018583830111156200043757600080fd5b62000444838284620004dc565b50505092915050565b6000602082840312156200046057600080fd5b81516001604060020a038111156200047757600080fd5b6200048584828501620003f1565b949350505050565b6040518181016001604060020a0381118282101715620004ac57600080fd5b604052919050565b60006001604060020a03821115620004cb57600080fd5b506020601f91909101601f19160190565b60005b83811015620004f9578181015183820152602001620004df565b8381111562000509576000848401525b50505050565b6159a1806200051f6000396000f3006080604052600436106101b65763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663288cdc9181146101bb578063297bb70b146101f15780632ac126221461021e5780633683ef8e1461024b5780633c28d8611461026d5780633e228bae1461029a5780633fd3c997146102ba5780634ac14782146102e75780634d0ae546146103075780634f9559b11461032757806350dde190146103475780636070410814610367578063642f2eaf1461039457806364a3bc15146103b457806377fcce68146103d45780637b8e3514146103f45780637e1d9808146104145780637e9d74dc1461043457806382c174d0146104615780638da5cb5b146104815780639363470214610496578063a3e20380146104b6578063b4be83d5146104d6578063bfc8bfce146104f6578063c585bb9314610516578063c75e0a8114610536578063d46b02c314610563578063d9bfa73e14610583578063db123b1a146105a3578063dd1c7d18146105c5578063e306f779146105e5578063e5fa431b146105fa578063eea086ba1461061a578063f2fde38b1461062f578063ffa1ad741461064f575b600080fd5b3480156101c757600080fd5b506101db6101d63660046148ee565b610664565b6040516101e89190615513565b60405180910390f35b3480156101fd57600080fd5b5061021161020c366004614811565b610676565b6040516101e891906157ed565b34801561022a57600080fd5b5061023e6102393660046148ee565b6107a1565b6040516101e89190615505565b34801561025757600080fd5b5061026b61026636600461492b565b6107b6565b005b34801561027957600080fd5b5061028d610288366004614a5f565b6108a3565b6040516101e891906157fb565b3480156102a657600080fd5b506102116102b5366004614b1f565b610a3a565b3480156102c657600080fd5b506102da6102d53660046149ee565b610a90565b6040516101e891906155cf565b3480156102f357600080fd5b5061026b6103023660046147dc565b610ab8565b34801561031357600080fd5b50610211610322366004614811565b610b85565b34801561033357600080fd5b5061026b6103423660046148ee565b610c75565b34801561035357600080fd5b50610211610362366004614811565b610e2a565b34801561037357600080fd5b506103876103823660046149ee565b610ebe565b6040516101e89190615425565b3480156103a057600080fd5b5061023e6103af3660046148ee565b610f0c565b3480156103c057600080fd5b506102116103cf366004614b1f565b610f21565b3480156103e057600080fd5b5061026b6103ef3660046147ac565b610fcc565b34801561040057600080fd5b5061023e61040f366004614772565b611106565b34801561042057600080fd5b5061021161042f3660046148a5565b611126565b34801561044057600080fd5b5061045461044f3660046147dc565b61128a565b6040516101e891906154f4565b34801561046d57600080fd5b5061023e61047c36600461490c565b61131f565b34801561048d57600080fd5b5061038761133f565b3480156104a257600080fd5b5061023e6104b1366004614993565b61135b565b3480156104c257600080fd5b506102116104d13660046148a5565b6118de565b3480156104e257600080fd5b506102116104f1366004614b1f565b6119f1565b34801561050257600080fd5b5061026b610511366004614b68565b611a6c565b34801561052257600080fd5b5061026b610531366004614754565b611d05565b34801561054257600080fd5b50610556610551366004614a2a565b611f30565b6040516101e8919061580a565b34801561056f57600080fd5b5061026b61057e366004614a2a565b61202a565b34801561058f57600080fd5b506101db61059e366004614772565b6120c6565b3480156105af57600080fd5b506105b86120e3565b6040516101e891906155be565b3480156105d157600080fd5b506102116105e03660046148a5565b61218e565b3480156105f157600080fd5b506101db612263565b34801561060657600080fd5b506102116106153660046148a5565b612269565b34801561062657600080fd5b506103876123db565b34801561063b57600080fd5b5061026b61064a366004614754565b6123f7565b34801561065b57600080fd5b506105b86124a8565b60046020526000908152604090205481565b61067e614386565b600080610689614386565b60005460ff16156106cf576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b60405180910390fd5b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011781558751935091505b81831461076f57610758878381518110151561071957fe5b90602001906020020151878481518110151561073157fe5b90602001906020020151878581518110151561074957fe5b906020019060200201516124df565b9050610764848261257d565b600190910190610701565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169055509392505050565b60056020526000908152604090205460ff1681565b73ffffffffffffffffffffffffffffffffffffffff831633146108465761080e848484848080601f0160208091040260200160405190810160405280939291908181526020018383808284375061135b945050505050565b1515610846576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061569d565b5050600091825260076020908152604080842073ffffffffffffffffffffffffffffffffffffffff9093168452919052902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055565b6108ab6143af565b6108b36143de565b6108bb6143de565b6000805460ff16156108f9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905561016080890151610140808a01919091528901519088015261094588611f30565b925061095087611f30565b915061095a6125df565b905061096888848389612611565b61097487838388612611565b61097e88886127a9565b610992888885604001518560400151612809565b8051602081015190519195506109ad918a9186918190612990565b6020808501519081015190516109c99189918591908190612990565b6109e28882856020015186604001518860000151612aa9565b6109fb8782846020015185604001518860200151612aa9565b610a0788888387612b55565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016905550949350505050565b610a42614386565b6060610a4f858585612d2d565b9050608081825160208401305af48015610a8657815183526020820151602084015260408201516040840152606082015160608401525b505b509392505050565b600b6020526000908152604090205473ffffffffffffffffffffffffffffffffffffffff1681565b60008054819060ff1615610af8576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011781558151905b808214610b5857610b508382815181101515610b4157fe5b90602001906020020151612eff565b600101610b29565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016905550565b610b8d614386565b600080610b98614386565b60005460ff1615610bd5576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011781558751935091505b81831461076f57610c5e8783815181101515610c1f57fe5b906020019060200201518784815181101515610c3757fe5b906020019060200201518785815181101515610c4f57fe5b90602001906020020151612f2a565b9050610c6a848261257d565b600190910190610c07565b6000805481908190819060ff1615610cb9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055610cec6125df565b935073ffffffffffffffffffffffffffffffffffffffff84163314610d115733610d14565b60005b73ffffffffffffffffffffffffffffffffffffffff8086166000908152600660209081526040808320938516835292905220549093506001860192509050808211610d8b576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061572d565b73ffffffffffffffffffffffffffffffffffffffff80851660008181526006602090815260408083209488168084529490915290819020859055517f82af639571738f4ebd4268fb0363d8957ebe1bbb9e78dba5ebd69eed39b154f090610df3908690615513565b60405180910390a35050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169055505050565b610e32614386565b600080610e3d614386565b86519250600091505b818314610eb457610e9d8783815181101515610e5e57fe5b906020019060200201518784815181101515610e7657fe5b906020019060200201518785815181101515610e8e57fe5b90602001906020020151610a3a565b9050610ea9848261257d565b600190910190610e46565b5050509392505050565b7fffffffff0000000000000000000000000000000000000000000000000000000081166000908152600b602052604090205473ffffffffffffffffffffffffffffffffffffffff165b919050565b60096020526000908152604090205460ff1681565b610f29614386565b60005460ff1615610f66576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055610f9c848484612f2a565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169055949350505050565b6000805460ff161561100a576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905561103d6125df565b73ffffffffffffffffffffffffffffffffffffffff8181166000818152600860209081526040808320948916808452949091529081902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00168715151790555192935090917fa8656e308026eeabce8f0bc18048433252318ab80ac79da0b3d3d8697dfba891906110d1908690615505565b60405180910390a35050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016905550565b600860209081526000928352604080842090915290825290205460ff1681565b61112e614386565b6060600080600061113d614386565b60005460ff161561117a576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117815589518a919081106111b257fe5b906020019060200201516101600151945088519350600092505b828414611255578489848151811015156111e257fe5b906020019060200201516101600181905250611202888760200151612f7d565b915061122e898481518110151561121557fe5b9060200190602002015183898681518110151561074957fe5b905061123a868261257d565b6020860151881161124a57611255565b6001909201916111cc565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169055509195945050505050565b606060006060600084519250826040519080825280602002602001820160405280156112d057816020015b6112bd6143de565b8152602001906001900390816112b55790505b509150600090505b808314610a88576112ff85828151811015156112f057fe5b90602001906020020151611f30565b828281518110151561130d57fe5b602090810290910101526001016112d8565b600760209081526000928352604080842090915290825290205460ff1681565b60035473ffffffffffffffffffffffffffffffffffffffff1681565b600080600080600080600080600089511115156113a4576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061571d565b6113ad89612fc4565b7f010000000000000000000000000000000000000000000000000000000000000090049650600760ff88161061140f576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061563d565b8660ff16600781111561141e57fe5b9550600086600781111561142e57fe5b1415611466576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061570d565b600186600781111561147457fe5b14156114bc578851156114b3576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906157dd565b600097506118d0565b60028660078111156114ca57fe5b141561160557885160411461150b576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906155dd565b88600081518110151561151a57fe5b01602001517f010000000000000000000000000000000000000000000000000000000000000090819004810204945061155a89600163ffffffff61308816565b935061156d89602163ffffffff61308816565b925060018b86868660405160008152602001604052604051611592949392919061556e565b60206040516020810390808403906000865af11580156115b6573d6000803e3d6000fd5b50506040517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0015173ffffffffffffffffffffffffffffffffffffffff8c811690821614995092506118d09050565b600386600781111561161357fe5b14156117b9578851604114611654576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906155dd565b88600081518110151561166357fe5b01602001517f01000000000000000000000000000000000000000000000000000000000000009081900481020494506116a389600163ffffffff61308816565b93506116b689602163ffffffff61308816565b925060018b60405160200180807f19457468657265756d205369676e6564204d6573736167653a0a333200000000815250601c0182600019166000191681526020019150506040516020818303038152906040526040518082805190602001908083835b6020831061175757805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0909201916020918201910161171a565b51815160209384036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01801990921691161790526040805192909401829003822060008352910192839052611592945092508991899150889061556e565b60048660078111156117c757fe5b14156117df576117d88b8b8b6130d3565b97506118d0565b60058660078111156117ed57fe5b1415611850576117fc89613228565b73ffffffffffffffffffffffffffffffffffffffff808c1660009081526008602090815260408083209385168352929052205490915060ff16151561184457600097506118d0565b6117d8818c8c8c6132a1565b600686600781111561185e57fe5b141561189e5760008b815260076020908152604080832073ffffffffffffffffffffffffffffffffffffffff8e16845290915290205460ff1697506118d0565b6040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061563d565b505050505050509392505050565b6118e6614386565b60606000806000806118f6614386565b89600081518110151561190557fe5b906020019060200201516101400151955089519450600093505b8385146119e457858a8581518110151561193557fe5b6020908102909101015161014001528651611951908a90612f7d565b92506119948a8581518110151561196457fe5b9060200190602002015160a001518b8681518110151561198057fe5b9060200190602002015160800151856133fd565b91506119c08a858151811015156119a757fe5b90602001906020020151838a87815181101515610e8e57fe5b90506119cc878261257d565b865189116119d9576119e4565b60019093019261191f565b5050505050509392505050565b6119f9614386565b60005460ff1615611a36576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055610f9c8484846124df565b600a5460009073ffffffffffffffffffffffffffffffffffffffff1615611abf576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b611b02611afd888888888080601f01602080910402602001604051908101604052809392919081815260200183838082843750613453945050505050565b613694565b60008181526009602052604090205490915060ff1615611b4e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061568d565b73ffffffffffffffffffffffffffffffffffffffff86163314611c1f57611ba6818785858080601f0160208091040260200160405190810160405280939291908181526020018383808284375061135b945050505050565b1515611bde576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906157cd565b600a80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff88161790555b6000818152600960205260409081902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011790555130908690869080838380828437820191505092505050600060405180830381855af49150501515611cb6576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156bd565b73ffffffffffffffffffffffffffffffffffffffff86163314611cfc57600a80547fffffffffffffffffffffffff00000000000000000000000000000000000000001690555b50505050505050565b6003546000908190819073ffffffffffffffffffffffffffffffffffffffff163314611d5d576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061577d565b8392508273ffffffffffffffffffffffffffffffffffffffff1663ae25532e6040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b158015611dc457600080fd5b505af1158015611dd8573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250611dfc9190810190614a0c565b7fffffffff0000000000000000000000000000000000000000000000000000000081166000908152600b602052604090205490925073ffffffffffffffffffffffffffffffffffffffff1690508015611e81576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061561d565b7fffffffff0000000000000000000000000000000000000000000000000000000082166000908152600b60205260409081902080547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff8616179055517fd2c6b762299c609bdb96520b58a49bfb80186934d4f71a86a367571a15c0319490611f2290849087906155a3565b60405180910390a150505050565b611f386143de565b611f41826136d1565b6020808301829052600091825260049052604090819020549082015260808201511515611f755760015b60ff168152610f07565b60a08201511515611f87576002611f6b565b60a0820151604082015110611f9d576005611f6b565b6101008201514210611fb0576004611f6b565b60208082015160009081526005909152604090205460ff1615611fd4576006611f6b565b610120820151825173ffffffffffffffffffffffffffffffffffffffff90811660009081526006602090815260408083206060880151909416835292905220541115612021576006611f6b565b60038152919050565b60005460ff1615612067576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016600117905561209b81612eff565b50600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169055565b600660209081526000928352604080842090915290825290205481565b60018054604080516020600284861615610100027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0190941693909304601f810184900484028201840190925281815292918301828280156121865780601f1061215b57610100808354040283529160200191612186565b820191906000526020600020905b81548152906001019060200180831161216957829003601f168201915b505050505081565b612196614386565b606060008060006121a5614386565b8860008151811015156121b457fe5b906020019060200201516101600151945088519350600092505b828414612257578489848151811015156121e457fe5b906020019060200201516101600181905250612204888760200151612f7d565b9150612230898481518110151561221757fe5b90602001906020020151838986815181101515610e8e57fe5b905061223c868261257d565b6020860151881161224c57612257565b6001909201916121ce565b50505050509392505050565b60025481565b612271614386565b6060600080600080612281614386565b60005460ff16156122be576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061576d565b600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011781558a518b919081106122f657fe5b906020019060200201516101400151955089519450600093505b8385146123a557858a8581518110151561232657fe5b6020908102909101015161014001528651612342908a90612f7d565b92506123558a8581518110151561196457fe5b91506123818a8581518110151561236857fe5b90602001906020020151838a8781518110151561074957fe5b905061238d878261257d565b8651891161239a576123a5565b600190930192612310565b5050600080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0016905550929695505050505050565b600a5473ffffffffffffffffffffffffffffffffffffffff1681565b60035473ffffffffffffffffffffffffffffffffffffffff163314612448576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061577d565b73ffffffffffffffffffffffffffffffffffffffff8116156124a557600380547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83161790555b50565b60408051808201909152600581527f322e302e30000000000000000000000000000000000000000000000000000000602082015281565b6124e7614386565b6124ef6143de565b60008060006124fd88611f30565b93506125076125df565b925061251588858589612611565b6125278860a001518560400151612f7d565b915061253387836136df565b9050612546888589848960000151612990565b61255088826136f5565b945061256788848660200151876040015189612aa9565b612572888487613756565b505050509392505050565b8151815161258b9190613864565b8252602080830151908201516125a19190613864565b6020830152604080830151908201516125ba9190613864565b6040830152606080830151908201516125d39190613864565b60609092019190915250565b600a5460009073ffffffffffffffffffffffffffffffffffffffff16818115612608578161260a565b335b9392505050565b825160ff1660031461264f576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061579d565b606084015173ffffffffffffffffffffffffffffffffffffffff16156126c257606084015173ffffffffffffffffffffffffffffffffffffffff1633146126c2576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906157ad565b602084015173ffffffffffffffffffffffffffffffffffffffff161561274d578173ffffffffffffffffffffffffffffffffffffffff16846020015173ffffffffffffffffffffffffffffffffffffffff1614151561274d576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906155ed565b604083015115156127a35761276b836020015185600001518361135b565b15156127a3576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061565d565b50505050565b6127bb8260a001518260a001516138ae565b6127cd836080015183608001516138ae565b1015612805576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906157bd565b5050565b6128116143af565b6000806000806128258960a0015188612f7d565b935061283a89608001518a60a0015186613909565b925061284a8860a0015187612f7d565b915061285f88608001518960a0015184613909565b90508084106128a25760208086018051839052805182018490525151865182015260808a015160a08b015187519092015161289a9290613909565b8551526128df565b845183905284516020908101859052855181015190860180519190915260a089015160808a01519151516128d69290613986565b60208087015101525b84515160208087015101516128f49190612f7d565b604086015284515160808a015160c08b0151612911929190613909565b85516040015284516020015160a08a015160e08b0151612932929190613909565b855160600152602085015151608089015160c08a0151612953929190613909565b8560200151604001818152505061297b8560200151602001518960a001518a60e00151613909565b60208601516060015250505050949350505050565b8215156129c9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156dd565b82821115612a03576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156cd565b8460a00151612a16856040015184613864565b1115612a4e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906155fd565b612a5c8560800151836138ae565b612a6a828760a001516138ae565b1115612aa2576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061575d565b5050505050565b612ab7828260200151613864565b600084815260046020908152604091829020929092558681015187518451938501518584015160608701516101408c01516101608d015196518b9873ffffffffffffffffffffffffffffffffffffffff9788169897909616967f0bcc4c97732e47d9946f229edb95f5b6323f601300e4690de719993f3c37112996612b46968f96339692959194909390615433565b60405180910390a45050505050565b60018054604080516020601f60027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6101008789161502019095169490940493840181900481028201810190925282815260609390929091830182828015612bfe5780601f10612bd357610100808354040283529160200191612bfe565b820191906000526020600020905b815481529060010190602001808311612be157829003601f168201915b50505050509050612c2685610140015186600001518660000151856020015160200151613a23565b61014084015184518651845160200151612c4293929190613a23565b612c5b8561014001518660000151858560400151613a23565b612c778186600001518760400151856000015160400151613a23565b612c938185600001518660400151856020015160400151613a23565b836040015173ffffffffffffffffffffffffffffffffffffffff16856040015173ffffffffffffffffffffffffffffffffffffffff161415612cfd57612cf881848760400151612cf3866000015160600151876020015160600151613864565b613a23565b612aa2565b612d1581848760400151856000015160600151613a23565b612aa281848660400151856020015160600151613a23565b604080517fb4be83d5000000000000000000000000000000000000000000000000000000006020808301919091526060602483018181528751608485019081528884015160a48601529488015160c48501529087015160e4840152608087015161010484015260a087015161012484015260c087015161014484015260e08701516101648401526101008701516101848401526101208701516101a4840152610140870180516101c485019081526101608901516101e4860152610180905251805161020485018190529394919384936044870192849261022489019291820191601f82010460005b81811015612e34578351855260209485019490930192600101612e16565b50505050818103610160808401919091528a0151805180835260209283019291820191601f82010460005b81811015612e7d578351855260209485019490930192600101612e5f565b50505089845250848103602093840190815288518083529093918201918981019190601f82010460005b81811015612ec5578351855260209485019490930192600101612ea7565b5050507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe08883030188525060405250505050509392505050565b612f076143de565b612f1082611f30565b9050612f1c8282613bed565b612805828260200151613d04565b612f32614386565b612f3d8484846124df565b6020810151909150831461260a576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061574d565b600082821115612fb9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061560d565b508082035b92915050565b6000808251111515613002576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156fd565b815182907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810190811061303257fe5b016020015182517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01909252507f0100000000000000000000000000000000000000000000000000000000000000908190040290565b6000816020018351101515156130ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061562d565b50016020015190565b6040516000906060907f1626ba7e000000000000000000000000000000000000000000000000000000009061310e908790869060240161554e565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152919052602080820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167fffffffff00000000000000000000000000000000000000000000000000000000909416939093178352815191935090829081885afa8080156131ab576001811461321c57612572565b7f08c379a0000000000000000000000000000000000000000000000000000000006000527c20000000000000000000000000000000000000000000000000000000006020527c0c57414c4c45545f4552524f5200000000000000000000000000000000604052600060605260646000fd5b50505195945050505050565b60006014825110151515613268576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061578d565b613276826014845103613dab565b82517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec019092525090565b6040516000906060907f9363470200000000000000000000000000000000000000000000000000000000906132de90879087908790602401615521565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152919052602080820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167fffffffff000000000000000000000000000000000000000000000000000000009094169390931783528151919350908290818a5afa80801561337b57600181146133ec576133f1565b7f08c379a0000000000000000000000000000000000000000000000000000000006000527c20000000000000000000000000000000000000000000000000000000006020527c0f56414c494441544f525f4552524f5200000000000000000000000000604052600060605260646000fd5b825194505b50505050949350505050565b6000808311613438576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061564d565b61344b61344585846138ae565b84613e0c565b949350505050565b604080517f5a65726f45785472616e73616374696f6e2800000000000000000000000000006020808301919091527f75696e743235362073616c742c0000000000000000000000000000000000000060328301527f61646472657373207369676e6572416464726573732c00000000000000000000603f8301527f627974657320646174610000000000000000000000000000000000000000000060558301527f2900000000000000000000000000000000000000000000000000000000000000605f830152825180830384018152606090920192839052815160009384938493909282918401908083835b6020831061357c57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0909201916020918201910161353f565b51815160209384036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff018019909216911617905260405191909301819003812089519097508995509093508392850191508083835b6020831061361257805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe090920191602091820191016135d5565b51815160209384036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01801990921691161790526040805192909401829003822097825281019a909a525073ffffffffffffffffffffffffffffffffffffffff97909716968801969096525050606085015250506080909120919050565b600280546040517f190100000000000000000000000000000000000000000000000000000000000081529182015260228101919091526042902090565b6000612fbe611afd83613e23565b60008183106136ee578161260a565b5090919050565b6136fd614386565b6020810182905260a08301516080840151613719918491613909565b808252608084015160c0850151613731929190613909565b604082015260a083015160e084015161374b918491613909565b606082015292915050565b60018054604080516020601f60027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff61010087891615020190951694909404938401819004810282018101909252828152606093909290918301828280156137ff5780601f106137d4576101008083540402835291602001916137ff565b820191906000526020600020905b8154815290600101906020018083116137e257829003601f168201915b5050505050905061381f8461014001518560000151858560000151613a23565b6138388461016001518486600001518560200151613a23565b61385081856000015186604001518560400151613a23565b6127a3818486604001518560600151613a23565b6000828201838110156138a3576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061567d565b8091505b5092915050565b6000808315156138c157600091506138a7565b508282028284828115156138d157fe5b04146138a3576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061567d565b6000808311613944576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061564d565b61394f84848461427c565b15613438576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156ad565b60008083116139c1576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061564d565b6139cc848484614301565b15613a03576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156ad565b61344b613445613a1386856138ae565b613a1e866001612f7d565b613864565b600080600083118015613a6257508373ffffffffffffffffffffffffffffffffffffffff168573ffffffffffffffffffffffffffffffffffffffff1614155b15613be5578551600310613aa2576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061573d565b50506020848101517fffffffff00000000000000000000000000000000000000000000000000000000166000818152600b90925260409091205473ffffffffffffffffffffffffffffffffffffffff16801515613b2b576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906156ed565b604051660fffffffffffe0603f885101168060840182017fa85e59e40000000000000000000000000000000000000000000000000000000083526080600484015273ffffffffffffffffffffffffffffffffffffffff8816602484015273ffffffffffffffffffffffffffffffffffffffff87166044840152856064840152608483015b81811015613bc757895181526020998a019901613baf565b61020084858403866000895af1801515613bdf573d85fd5b50505050505b505050505050565b805160009060ff16600314613c2e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061579d565b606083015173ffffffffffffffffffffffffffffffffffffffff1615613ca157606083015173ffffffffffffffffffffffffffffffffffffffff163314613ca1576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c6906157ad565b613ca96125df565b835190915073ffffffffffffffffffffffffffffffffffffffff808316911614613cff576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061566d565b505050565b6000818152600560205260409081902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001660011790558281015183516101408501516101608601519351859473ffffffffffffffffffffffffffffffffffffffff9485169493909316927fdc47b3613d9fe400085f6dbdc99453462279057e6207385042827ed6b1a62cf792613d9f923392906154b7565b60405180910390a45050565b600081601401835110151515613ded576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061578d565b50016014015173ffffffffffffffffffffffffffffffffffffffff1690565b6000808284811515613e1a57fe5b04949350505050565b604080517f4f726465722800000000000000000000000000000000000000000000000000006020808301919091527f61646472657373206d616b6572416464726573732c000000000000000000000060268301527f616464726573732074616b6572416464726573732c0000000000000000000000603b8301527f6164647265737320666565526563697069656e74416464726573732c0000000060508301527f616464726573732073656e646572416464726573732c00000000000000000000606c8301527f75696e74323536206d616b65724173736574416d6f756e742c0000000000000060828301527f75696e743235362074616b65724173736574416d6f756e742c00000000000000609b8301527f75696e74323536206d616b65724665652c00000000000000000000000000000060b48301527f75696e743235362074616b65724665652c00000000000000000000000000000060c58301527f75696e743235362065787069726174696f6e54696d655365636f6e64732c000060d68301527f75696e743235362073616c742c0000000000000000000000000000000000000060f48301527f6279746573206d616b65724173736574446174612c00000000000000000000006101018301527f62797465732074616b65724173736574446174610000000000000000000000006101168301527f290000000000000000000000000000000000000000000000000000000000000061012a830152825161010b81840301815261012b90920192839052815160009384938493849391929182918401908083835b602083106140ab57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0909201916020918201910161406e565b51815160209384036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01801990921691161790526040519190930181900381206101408b0151805191995095509093508392850191508083835b6020831061414657805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101614109565b51815160209384036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01801990921691161790526040519190930181900381206101608b0151805191985095509093508392850191508083835b602083106141e157805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe090920191602091820191016141a4565b5181516020939093036101000a7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff018019909116921691909117905260405192018290039091207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0890180516101408b018051610160909c0180519a84529881529288526101a0822091529890525050509190525090919050565b6000808084116142b8576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061564d565b8215806142c3575084155b156142d15760009150610a88565b838015156142db57fe5b85840990506142ea85846138ae565b6142f66103e8836138ae565b101595945050505050565b60008080841161433d576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016106c69061564d565b821580614348575084155b156143565760009150610a88565b8380151561436057fe5b8584099050836143708583612f7d565b81151561437957fe5b0690506142ea85846138ae565b608060405190810160405280600081526020016000815260200160008152602001600081525090565b610120604051908101604052806143c4614386565b81526020016143d1614386565b8152602001600081525090565b604080516060810182526000808252602082018190529181019190915290565b600061260a82356158b0565b6000601f8201831361441b57600080fd5b813561442e6144298261583f565b615818565b81815260209384019390925082018360005b8381101561446c578135860161445688826145bc565b8452506020928301929190910190600101614440565b5050505092915050565b6000601f8201831361448757600080fd5b81356144956144298261583f565b81815260209384019390925082018360005b8381101561446c57813586016144bd888261460b565b84525060209283019291909101906001016144a7565b6000601f820183136144e457600080fd5b81356144f26144298261583f565b9150818183526020840193506020810190508385602084028201111561451757600080fd5b60005b8381101561446c578161452d888261454f565b845250602092830192919091019060010161451a565b600061260a82356158c9565b600061260a82356158ce565b600061260a82356158d1565b600061260a82516158d1565b600080601f8301841361458557600080fd5b50813567ffffffffffffffff81111561459d57600080fd5b6020830191508360018202830111156145b557600080fd5b9250929050565b6000601f820183136145cd57600080fd5b81356145db61442982615860565b915080825260208301602083018583830111156145f757600080fd5b614602838284615907565b50505092915050565b6000610180828403121561461e57600080fd5b614629610180615818565b9050600061463784846143fe565b8252506020614648848483016143fe565b602083015250604061465c848285016143fe565b6040830152506060614670848285016143fe565b60608301525060806146848482850161454f565b60808301525060a06146988482850161454f565b60a08301525060c06146ac8482850161454f565b60c08301525060e06146c08482850161454f565b60e0830152506101006146d58482850161454f565b610100830152506101206146eb8482850161454f565b6101208301525061014082013567ffffffffffffffff81111561470d57600080fd5b614719848285016145bc565b6101408301525061016082013567ffffffffffffffff81111561473b57600080fd5b614747848285016145bc565b6101608301525092915050565b60006020828403121561476657600080fd5b600061344b84846143fe565b6000806040838503121561478557600080fd5b600061479185856143fe565b92505060206147a2858286016143fe565b9150509250929050565b600080604083850312156147bf57600080fd5b60006147cb85856143fe565b92505060206147a285828601614543565b6000602082840312156147ee57600080fd5b813567ffffffffffffffff81111561480557600080fd5b61344b84828501614476565b60008060006060848603121561482657600080fd5b833567ffffffffffffffff81111561483d57600080fd5b61484986828701614476565b935050602084013567ffffffffffffffff81111561486657600080fd5b614872868287016144d3565b925050604084013567ffffffffffffffff81111561488f57600080fd5b61489b8682870161440a565b9150509250925092565b6000806000606084860312156148ba57600080fd5b833567ffffffffffffffff8111156148d157600080fd5b6148dd86828701614476565b93505060206148728682870161454f565b60006020828403121561490057600080fd5b600061344b848461454f565b6000806040838503121561491f57600080fd5b6000614791858561454f565b6000806000806060858703121561494157600080fd5b600061494d878761454f565b945050602061495e878288016143fe565b935050604085013567ffffffffffffffff81111561497b57600080fd5b61498787828801614573565b95989497509550505050565b6000806000606084860312156149a857600080fd5b60006149b4868661454f565b93505060206149c5868287016143fe565b925050604084013567ffffffffffffffff8111156149e257600080fd5b61489b868287016145bc565b600060208284031215614a0057600080fd5b600061344b848461455b565b600060208284031215614a1e57600080fd5b600061344b8484614567565b600060208284031215614a3c57600080fd5b813567ffffffffffffffff811115614a5357600080fd5b61344b8482850161460b565b60008060008060808587031215614a7557600080fd5b843567ffffffffffffffff811115614a8c57600080fd5b614a988782880161460b565b945050602085013567ffffffffffffffff811115614ab557600080fd5b614ac18782880161460b565b935050604085013567ffffffffffffffff811115614ade57600080fd5b614aea878288016145bc565b925050606085013567ffffffffffffffff811115614b0757600080fd5b614b13878288016145bc565b91505092959194509250565b600080600060608486031215614b3457600080fd5b833567ffffffffffffffff811115614b4b57600080fd5b614b578682870161460b565b93505060206149c58682870161454f565b60008060008060008060808789031215614b8157600080fd5b6000614b8d898961454f565b9650506020614b9e89828a016143fe565b955050604087013567ffffffffffffffff811115614bbb57600080fd5b614bc789828a01614573565b9450945050606087013567ffffffffffffffff811115614be657600080fd5b614bf289828a01614573565b92509250509295509295509295565b614c0a816158b0565b82525050565b6000614c1b826158ac565b808452602084019350614c2d836158a6565b60005b82811015614c5d57614c438683516153e5565b614c4c826158a6565b606096909601959150600101614c30565b5093949350505050565b614c0a816158c9565b614c0a816158ce565b614c0a816158d1565b6000614c8d826158ac565b808452614ca1816020860160208601615913565b614caa8161593f565b9093016020019392505050565b614c0a816158fc565b601281527f4c454e4754485f36355f52455155495245440000000000000000000000000000602082015260400190565b600d81527f494e56414c49445f54414b455200000000000000000000000000000000000000602082015260400190565b600e81527f4f524445525f4f56455246494c4c000000000000000000000000000000000000602082015260400190565b601181527f55494e543235365f554e444552464c4f57000000000000000000000000000000602082015260400190565b601a81527f41535345545f50524f58595f414c52454144595f455849535453000000000000602082015260400190565b602681527f475245415445525f4f525f455155414c5f544f5f33325f4c454e4754485f524560208201527f5155495245440000000000000000000000000000000000000000000000000000604082015260600190565b601581527f5349474e41545552455f554e535550504f525445440000000000000000000000602082015260400190565b601081527f4449564953494f4e5f42595f5a45524f00000000000000000000000000000000602082015260400190565b601781527f494e56414c49445f4f524445525f5349474e4154555245000000000000000000602082015260400190565b600d81527f494e56414c49445f4d414b455200000000000000000000000000000000000000602082015260400190565b601081527f55494e543235365f4f564552464c4f5700000000000000000000000000000000602082015260400190565b600f81527f494e56414c49445f54585f484153480000000000000000000000000000000000602082015260400190565b601181527f494e56414c49445f5349474e4154555245000000000000000000000000000000602082015260400190565b600e81527f524f554e44494e475f4552524f52000000000000000000000000000000000000602082015260400190565b601081527f4641494c45445f455845435554494f4e00000000000000000000000000000000602082015260400190565b600d81527f54414b45525f4f56455250415900000000000000000000000000000000000000602082015260400190565b601481527f494e56414c49445f54414b45525f414d4f554e54000000000000000000000000602082015260400190565b601a81527f41535345545f50524f58595f444f45535f4e4f545f4558495354000000000000602082015260400190565b602181527f475245415445525f5448414e5f5a45524f5f4c454e4754485f5245515549524560208201527f4400000000000000000000000000000000000000000000000000000000000000604082015260600190565b601181527f5349474e41545552455f494c4c4547414c000000000000000000000000000000602082015260400190565b601e81527f4c454e4754485f475245415445525f5448414e5f305f52455155495245440000602082015260400190565b601781527f494e56414c49445f4e45575f4f524445525f45504f4348000000000000000000602082015260400190565b601e81527f4c454e4754485f475245415445525f5448414e5f335f52455155495245440000602082015260400190565b601481527f434f4d504c4554455f46494c4c5f4641494c4544000000000000000000000000602082015260400190565b601281527f494e56414c49445f46494c4c5f50524943450000000000000000000000000000602082015260400190565b601281527f5245454e5452414e43595f494c4c4547414c0000000000000000000000000000602082015260400190565b601381527f4f4e4c595f434f4e54524143545f4f574e455200000000000000000000000000602082015260400190565b602681527f475245415445525f4f525f455155414c5f544f5f32305f4c454e4754485f524560208201527f5155495245440000000000000000000000000000000000000000000000000000604082015260600190565b601081527f4f524445525f554e46494c4c41424c4500000000000000000000000000000000602082015260400190565b600e81527f494e56414c49445f53454e444552000000000000000000000000000000000000602082015260400190565b601881527f4e454741544956455f5350524541445f52455155495245440000000000000000602082015260400190565b601481527f494e56414c49445f54585f5349474e4154555245000000000000000000000000602082015260400190565b601181527f4c454e4754485f305f5245515549524544000000000000000000000000000000602082015260400190565b805160808301906153738482614c70565b5060208201516153866020850182614c70565b5060408201516153996040850182614c70565b5060608201516127a36060850182614c70565b80516101208301906153be8482615362565b5060208201516153d16080850182615362565b5060408201516127a3610100850182614c70565b805160608301906153f6848261541c565b5060208201516154096020850182614c70565b5060408201516127a36040850182614c70565b614c0a816158f6565b60208101612fbe8284614c01565b6101008101615442828b614c01565b61544f602083018a614c01565b61545c6040830189614c70565b6154696060830188614c70565b6154766080830187614c70565b61548360a0830186614c70565b81810360c08301526154958185614c82565b905081810360e08301526154a98184614c82565b9a9950505050505050505050565b606081016154c58286614c01565b81810360208301526154d78185614c82565b905081810360408301526154eb8184614c82565b95945050505050565b6020808252810161260a8184614c10565b60208101612fbe8284614c67565b60208101612fbe8284614c70565b6060810161552f8286614c70565b61553c6020830185614c01565b81810360408301526154eb8184614c82565b6040810161555c8285614c70565b818103602083015261344b8184614c82565b6080810161557c8287614c70565b615589602083018661541c565b6155966040830185614c70565b6154eb6060830184614c70565b604081016155b18285614c79565b61260a6020830184614c01565b6020808252810161260a8184614c82565b60208101612fbe8284614cb7565b60208082528101612fbe81614cc0565b60208082528101612fbe81614cf0565b60208082528101612fbe81614d20565b60208082528101612fbe81614d50565b60208082528101612fbe81614d80565b60208082528101612fbe81614db0565b60208082528101612fbe81614e06565b60208082528101612fbe81614e36565b60208082528101612fbe81614e66565b60208082528101612fbe81614e96565b60208082528101612fbe81614ec6565b60208082528101612fbe81614ef6565b60208082528101612fbe81614f26565b60208082528101612fbe81614f56565b60208082528101612fbe81614f86565b60208082528101612fbe81614fb6565b60208082528101612fbe81614fe6565b60208082528101612fbe81615016565b60208082528101612fbe81615046565b60208082528101612fbe8161509c565b60208082528101612fbe816150cc565b60208082528101612fbe816150fc565b60208082528101612fbe8161512c565b60208082528101612fbe8161515c565b60208082528101612fbe8161518c565b60208082528101612fbe816151bc565b60208082528101612fbe816151ec565b60208082528101612fbe8161521c565b60208082528101612fbe81615272565b60208082528101612fbe816152a2565b60208082528101612fbe816152d2565b60208082528101612fbe81615302565b60208082528101612fbe81615332565b60808101612fbe8284615362565b6101208101612fbe82846153ac565b60608101612fbe82846153e5565b60405181810167ffffffffffffffff8111828210171561583757600080fd5b604052919050565b600067ffffffffffffffff82111561585657600080fd5b5060209081020190565b600067ffffffffffffffff82111561587757600080fd5b506020601f919091017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0160190565b60200190565b5190565b73ffffffffffffffffffffffffffffffffffffffff1690565b151590565b90565b7fffffffff000000000000000000000000000000000000000000000000000000001690565b60ff1690565b6000612fbe826158b0565b82818337506000910152565b60005b8381101561592e578181015183820152602001615916565b838111156127a35750506000910152565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016905600a265627a7a72305820d41ee66f45c4d1637cb6e5f109447c6d5d7fef3204a685dc442151c0f029b7da6c6578706572696d656e74616cf50037"
+            }
+        }
+    },
+    "networks": {}
+}

--- a/unit/Language/Solidity/Test/AbiSpec.hs
+++ b/unit/Language/Solidity/Test/AbiSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.Solidity.Test.AbiSpec where
+
+
+import Test.Hspec
+import Data.Either (isLeft)
+import Language.Solidity.Abi
+
+
+spec :: Spec
+spec = do
+  describe "parseSolidityType" $ 
+    describe "tuple type" $ do
+        it "can parses a FunctionArg with tuple type" $ do
+          let maa = FunctionArg  "makerAssetAmount" "uint256" Nothing
+              ma = FunctionArg "makeAddress" "address" Nothing
+              tupleFA = FunctionArg "order" "tuple" (Just [maa, ma])
+              eRes = parseSolidityFunctionArgType tupleFA
+          eRes `shouldBe` Right (SolidityTuple 2 [SolidityUint 256, SolidityAddress])
+        it "fails to parse a FunctionArg with invalid tuple" $ do
+          let tupleFA = FunctionArg "order" "tuple" Nothing
+              eRes = parseSolidityFunctionArgType tupleFA
+          isLeft eRes `shouldBe` True 
+  describe "signature" $ 
+    it "can generate signature for fillOrder" $ do
+      let fillOrderDec = buildFillOrderDec
+          expected = "fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)"
+          sig = signature fillOrderDec
+      sig `shouldBe` expected
+  describe "methodId" $ 
+    it "can generate methodId for fillOrder" $ do
+      let fillOrderDec = buildFillOrderDec
+          expected = "0xb4be83d5"
+          mId = methodId fillOrderDec
+      mId `shouldBe` expected
+
+buildFillOrderDec :: Declaration
+buildFillOrderDec = DFunction "fillOrder" False funInputs' funOutputs'
+  where
+    funInputs' = 
+      [ makeTupleFuncArg ("order", "tuple") tupleComponents
+      , makeBasicFuncArg ("takerAssetFillAmount", "uint256")
+      , makeBasicFuncArg ("signature", "bytes")
+      ]
+    tupleComponents = 
+      [ ("makerAddress", "address")           
+      , ("takerAddress", "address")         
+      , ("feeRecipientAddress", "address")    
+      , ("senderAddress", "address")          
+      , ("makerAssetAmount", "uint256")       
+      , ("takerAssetAmount", "uint256")       
+      , ("makerFee", "uint256")               
+      , ("takerFee", "uint256")               
+      , ("expirationTimeSeconds", "uint256")
+      , ("salt", "uint256")                   
+      , ("makerAssetData",   "bytes")
+      , ("takerAssetData",   "bytes")
+      ]
+    funOutputs' = Nothing
+    makeBasicFuncArg (n,t) = 
+      FunctionArg n t Nothing
+    makeTupleFuncArg (n,t) cmps = 
+      FunctionArg n t (Just $ map makeBasicFuncArg cmps)

--- a/unit/Network/Ethereum/Contract/Test/THSpec.hs
+++ b/unit/Network/Ethereum/Contract/Test/THSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+module Network.Ethereum.Contract.Test.THSpec where
+
+
+import Test.Hspec
+import           Network.Ethereum.Contract.TH
+
+
+-- Contract with Tuples taken from:
+-- https://raw.githubusercontent.com/0xProject/0x-monorepo/%400x/website%400.0.89/packages/contract-artifacts/artifacts/Exchange.json
+[abiFrom|test/contracts/Exchange.json|]
+
+spec :: Spec
+spec = 
+  describe "quasi-quoter" $ 
+    it "can compile contract with tuples" $ 
+      True `shouldBe` True
+    
+
+

--- a/unit/Network/Ethereum/Contract/Test/THSpec.hs
+++ b/unit/Network/Ethereum/Contract/Test/THSpec.hs
@@ -12,7 +12,7 @@ import Test.Hspec
 import           Network.Ethereum.Contract.TH
 
 
--- Contract with Tuples taken from:
+-- 0x Exchange Contract that includes Tuples taken from:
 -- https://raw.githubusercontent.com/0xProject/0x-monorepo/%400x/website%400.0.89/packages/contract-artifacts/artifacts/Exchange.json
 [abiFrom|test/contracts/Exchange.json|]
 


### PR DESCRIPTION
This PR is for contracts that have `struct`s as function arguments, this is enabled in solidity files with the [ABIEncoderV2](https://solidity.readthedocs.io/en/v0.5.11/layout-of-source-files.html?highlight=abiEncoderV2#abiencoderv2). Currently, the TH fails with a parse failure.

[link for below example](https://github.com/0xProject/0x-monorepo/blob/development/contracts/exchange/contracts/src/MixinExchangeCore.sol#L90)
```Solidity
    function fillOrder(
        Order memory order,
        uint256 takerAssetFillAmount,
        bytes memory signature
    )
```
