### PR TITLE
Classify tuples as dynamic when a component type is dynamic

### DIFF
--- a/packages/solidity/src/Data/Solidity/Prim/Tuple/TH.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Tuple/TH.hs
@@ -17,8 +17,9 @@ module Data.Solidity.Prim.Tuple.TH (tupleDecs) where
 
 
 import           Control.Monad       (replicateM)
+import           Data.Proxy
 import           Language.Haskell.TH (DecsQ, Type (VarT), appT, clause, conT,
-                                      cxt, funD, instanceD, newName, normalB,
+                                      cxt, funD, instanceD, listE, newName, normalB,
                                       tupleT)
 
 import           Data.Solidity.Abi   (AbiGet, AbiPut, AbiType (..))
@@ -27,8 +28,10 @@ tupleDecs :: Int -> DecsQ
 tupleDecs n = do
     vars <- replicateM n $ newName "a"
     let types = fmap (pure . VarT) vars
+        areDynamic = listE $ flip fmap types $ \t -> [| isDynamic (Proxy :: Proxy $(t)) |]
+
     sequence $
       [ instanceD (cxt $ map (appT $ conT ''AbiType) types) (appT (conT ''AbiType) (foldl appT (tupleT n) types))
-          [funD 'isDynamic [clause [] (normalB [|const False|]) []]]
+          [funD 'isDynamic [clause [] (normalB [|const (or $(areDynamic))|]) []]]
       , instanceD (cxt $ map (appT $ conT ''AbiGet) types) (appT (conT ''AbiGet) (foldl appT (tupleT n) types)) []
       , instanceD (cxt $ map (appT $ conT ''AbiPut) types) (appT (conT ''AbiPut) (foldl appT (tupleT n) types)) [] ]


### PR DESCRIPTION
Had to deal with several combinations of nested reference types and ran into a couple bugs in solidity bindings.
Should be able to PR most of them in the next few days.
