### PR TITLE
Fallback to parsing 'constant' field for backwards compatibility

### DIFF
--- a/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
@@ -73,7 +73,6 @@ import           Language.Solidity.Abi            (ContractAbi (..),
                                                    EventArg (..),
                                                    FunctionArg (..),
                                                    SolidityType (..),
-                                                   StateMutability(..),
                                                    eventId,
                                                    methodId,
                                                    parseSolidityEventArgType,
@@ -229,8 +228,8 @@ mkDecl ev@(DEvent uncheckedName inputs anonymous) = sequence
 
 -- TODO change this type name also
 -- | Method declarations maker
-mkDecl fun@(DFunction name stateMutability inputs outputs) = (++)
-  <$> funWrapper (stateMutability `elem` [SMPure, SMView]) fnName dataName inputs outputs
+mkDecl fun@(DFunction name constant inputs outputs) = (++)
+  <$> funWrapper constant fnName dataName inputs outputs
   <*> sequence
         [ dataD' dataName (normalC dataName bangInput) derivingD
         , instanceD' dataName (conT ''Generic) []

--- a/packages/solidity/tests/Language/Solidity/Test/AbiSpec.hs
+++ b/packages/solidity/tests/Language/Solidity/Test/AbiSpec.hs
@@ -35,7 +35,7 @@ spec = do
       mId `shouldBe` expected
 
 buildFillOrderDec :: Declaration
-buildFillOrderDec = DFunction "fillOrder" SMNonPayable funInputs' funOutputs'
+buildFillOrderDec = DFunction "fillOrder" False funInputs' funOutputs'
   where
     funInputs' =
       [ makeTupleFuncArg ("order", "tuple") tupleComponents


### PR DESCRIPTION
I don't see a way to distinguish `view` and `pure` with only `constant` / `payable`, so I rolled back the `funStateMutability` field to what it was since its only current use is seeing whether it's `constant`.