### PR TITLE
Bump some cabal upper bounds

### DIFF
--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -16,7 +16,7 @@ dependencies:
 - aeson                >1.2  && <1.5
 - memory               >0.14 && <0.16
 - uuid-types           >1.0  && <1.1
-- cryptonite           >0.22 && <0.27
+- cryptonite           >0.22 && <0.28
 - bytestring           >0.10 && <0.11
 - web3-hexstring       >=1.0 && <1.1
 
@@ -53,7 +53,7 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
     - hspec-expectations   >=0.8.2  && <0.9

--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -13,7 +13,7 @@ category:            Network
 dependencies:
 - base                 >4.11 && <4.14
 - text                 >1.2  && <1.3
-- vinyl                >0.5  && <0.13
+- vinyl                >0.5  && <0.14
 - aeson                >1.2  && <1.5
 - tagged               >0.8  && <0.9
 - memory               >0.14 && <0.16
@@ -67,7 +67,7 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
     - hspec-expectations   >=0.8.2  && <0.9


### PR DESCRIPTION
We use nix+cabal and recent nixpkgs bring newer versions of cryptonite/vinyl. 
Doesn't seem like any of these bumps are in stackage, so not sure how to have CI test this change
