### PR TITLE
Fix bindings for single field structs

### DIFF
--- a/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
@@ -56,7 +56,7 @@ import           Data.Text                        (Text)
 import qualified Data.Text                        as T
 import qualified Data.Text.Lazy                   as LT
 import qualified Data.Text.Lazy.Encoding          as LT
-import           Data.Tuple.OneTuple              (only)
+import           Data.Tuple.OneTuple              (OneTuple, only)
 import           Generics.SOP                     (Generic)
 import qualified GHC.Generics                     as GHC (Generic)
 import           Language.Haskell.TH
@@ -120,6 +120,7 @@ toHSType s = case s of
     SolidityString      -> conT ''Text
     SolidityBytesN n    -> appT (conT ''BytesN) (numLit n)
     SolidityBytes       -> conT ''Bytes
+    SolidityTuple [a]   -> appT (conT ''OneTuple) (toHSType a)
     SolidityTuple as    -> foldl ( \b a -> appT b $ toHSType a ) ( tupleT (length as) ) as
     SolidityVector ns a -> expandVector ns a
     SolidityArray a     -> appT listT $ toHSType a

--- a/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
@@ -120,7 +120,7 @@ toHSType s = case s of
     SolidityString      -> conT ''Text
     SolidityBytesN n    -> appT (conT ''BytesN) (numLit n)
     SolidityBytes       -> conT ''Bytes
-    SolidityTuple n as  -> foldl ( \b a -> appT b $ toHSType a ) ( tupleT n ) as
+    SolidityTuple as    -> foldl ( \b a -> appT b $ toHSType a ) ( tupleT (length as) ) as
     SolidityVector ns a -> expandVector ns a
     SolidityArray a     -> appT listT $ toHSType a
   where

--- a/packages/ethereum/tests/Network/Ethereum/Test/THSpec.hs
+++ b/packages/ethereum/tests/Network/Ethereum/Test/THSpec.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE QuasiQuotes           #-}
 module Network.Ethereum.Test.THSpec where
 
+import           Data.Tuple.OneTuple (OneTuple(..))
 import           Network.Ethereum.Contract.TH
 import           Test.Hspec
 
@@ -13,8 +14,14 @@ import           Test.Hspec
 -- https://raw.githubusercontent.com/0xProject/0x-monorepo/%400x/website%400.0.89/packages/contract-artifacts/artifacts/Exchange.json
 [abiFrom|tests/contracts/Exchange.json|]
 
+[abiFrom|tests/contracts/SingleField.json|]
+
 spec :: Spec
 spec = parallel $
-  describe "quasi-quoter" $
+  describe "quasi-quoter" $ do
     it "can compile contract with tuples" $
+      True `shouldBe` True
+
+    it "can compile single field structs" $ do
+      let _ = SingleFieldFunctionData (OneTuple 123)
       True `shouldBe` True

--- a/packages/solidity/src/Language/Solidity/Abi.hs
+++ b/packages/solidity/src/Language/Solidity/Abi.hs
@@ -252,7 +252,7 @@ data SolidityType = SolidityBool
     | SolidityString
     | SolidityBytesN Int
     | SolidityBytes
-    | SolidityTuple Int [SolidityType]
+    | SolidityTuple [SolidityType]
     | SolidityVector [Int] SolidityType
     | SolidityArray SolidityType
     deriving (Eq, Show)
@@ -329,9 +329,7 @@ solidityTypeParser =
 parseSolidityFunctionArgType :: FunctionArg -> Either ParseError SolidityType
 parseSolidityFunctionArgType (FunctionArg _ typ mcmps) = case mcmps of
   Nothing -> parse solidityTypeParser "Solidity" typ
-  Just cmps ->
-    SolidityTuple (length cmps)
-    <$>  mapM parseSolidityFunctionArgType cmps
+  Just cmps -> SolidityTuple <$> mapM parseSolidityFunctionArgType cmps
 
 
 parseSolidityEventArgType :: EventArg -> Either ParseError SolidityType

--- a/packages/solidity/tests/Language/Solidity/Test/AbiSpec.hs
+++ b/packages/solidity/tests/Language/Solidity/Test/AbiSpec.hs
@@ -16,7 +16,7 @@ spec = parallel $ do
               ma = FunctionArg "makeAddress" "address" Nothing
               tupleFA = FunctionArg "order" "tuple" (Just [maa, ma])
               eRes = parseSolidityFunctionArgType tupleFA
-          eRes `shouldBe` Right (SolidityTuple 2 [SolidityUint 256, SolidityAddress])
+          eRes `shouldBe` Right (SolidityTuple [SolidityUint 256, SolidityAddress])
         it "fails to parse a FunctionArg with invalid tuple" $ do
           let tupleFA = FunctionArg "order" "tuple" Nothing
               eRes = parseSolidityFunctionArgType tupleFA


### PR DESCRIPTION
From https://docs.soliditylang.org/en/v0.8.0/abi-spec.html#formal-specification-of-the-encoding, when any field in a struct is dynamic, so is the struct - this means that the encoding of a struct with just one field which is dynamic will be
`enc(X) = head(X(1)) tail(X(1))` which is different than the field's encoding `tail(X(1))` so we need the generated type to have the `OneTuple` wrapper.

e.g. https://github.com/airalab/hs-web3/blob/a6e726af2552e5fd2c02b8db07784f41fd939af5/packages/solidity/tests/Data/Solidity/Test/EncodingSpec.hs#L151-L155
