### PR TITLE
Widen dependency version bounds

### DIFF
--- a/packages/bignum/package.yaml
+++ b/packages/bignum/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - memory               >0.14 && <0.16
 - cereal               >0.5  && <0.6
 - basement             >0.0  && <0.1

--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -15,9 +15,9 @@ extra-source-files:
 - src/cbits/xxhash.c
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - memory               >0.14 && <0.16
 - uuid-types           >1.0  && <1.1
 - cryptonite           >0.22 && <0.28

--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -11,10 +11,10 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
 - vinyl                >0.5  && <0.14
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - tagged               >0.8  && <0.9
 - memory               >0.14 && <0.16
 - relapse              >=1.0 && <2.0
@@ -27,7 +27,7 @@ dependencies:
 - data-default         >0.7  && <0.8
 - transformers         >0.5  && <0.6
 - microlens-aeson      >2.2  && <2.4
-- template-haskell     >2.11 && <2.16
+- template-haskell     >2.11 && <2.17
 - mtl                  >2.2  && <2.3
 - web3-crypto          >=1.0 && <1.1
 - web3-jsonrpc         >=1.0 && <1.1

--- a/packages/hexstring/package.yaml
+++ b/packages/hexstring/package.yaml
@@ -11,12 +11,12 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - memory               >0.14 && <0.16
 - bytestring           >0.10 && <0.11
-- template-haskell     >2.11 && <2.16
+- template-haskell     >2.11 && <2.17
 - web3-scale           >=1.0 && <1.1
 
 ghc-options:

--- a/packages/ipfs/package.yaml
+++ b/packages/ipfs/package.yaml
@@ -11,17 +11,17 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - mtl                  >2.2  && <2.3
 - tar                  >0.4  && <0.6  
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
-- servant              >0.12 && <0.17
+- aeson                >1.2  && <1.6
+- servant              >0.12 && <0.19
 - http-media           >0.6  && <0.8.1
 - bytestring           >0.10 && <0.11
 - http-types           >0.11 && <0.14 
 - http-client          >0.5  && <0.7
-- servant-client       >0.12 && <0.17
+- servant-client       >0.12 && <0.19
 - unordered-containers >0.1  && <0.3 
 
 ghc-options:

--- a/packages/jsonrpc/package.yaml
+++ b/packages/jsonrpc/package.yaml
@@ -11,9 +11,9 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - random               >1.0  && <1.2
 - bytestring           >0.10 && <0.11
 - exceptions           >0.8  && <0.11

--- a/packages/polkadot/package.yaml
+++ b/packages/polkadot/package.yaml
@@ -12,9 +12,9 @@ category:            Network
 
 dependencies:
 - mtl                  >2.2  && <2.3
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - parsec               >3.0  && <3.2
 - memory               >0.14 && <0.16
 - microlens            >0.4  && <0.5

--- a/packages/provider/package.yaml
+++ b/packages/provider/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - mtl                  >2.2  && <2.3
 - text                 >1.2  && <1.3
 - async                >2.1  && <2.3

--- a/packages/scale/package.yaml
+++ b/packages/scale/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
 - cereal               >0.5  && <0.6
 - bitvec               >1.0  && <2.0
@@ -20,7 +20,7 @@ dependencies:
 - bytestring           >0.10 && <0.11
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.16
+- template-haskell     >2.11 && <2.17
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/solidity/package.yaml
+++ b/packages/solidity/package.yaml
@@ -11,9 +11,9 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.5
+- aeson                >1.2  && <1.6
 - cereal               >0.5  && <0.6
 - memory               >0.14 && <0.16
 - tagged               >0.8  && <0.9
@@ -24,7 +24,7 @@ dependencies:
 - bytestring           >0.10 && <0.11
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.16
+- template-haskell     >2.11 && <2.17
 - web3-crypto          >=1.0 && <1.1
 - web3-hexstring       >=1.0 && <1.1
 

--- a/packages/web3/package.yaml
+++ b/packages/web3/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2020"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.14
+- base                 >4.11 && <4.15
 - web3-provider        >=1.0 && <1.1
 - web3-ethereum        >=1.0 && <1.1
 - web3-polkadot        >=1.0 && <1.1


### PR DESCRIPTION
With these changes the library builds against lts-17.7 on GHC 8.10.4. Tests pass.