### PR TITLE
Fix ghc 8.6

### DIFF
--- a/packages/polkadot/src/Network/Polkadot/Call.hs
+++ b/packages/polkadot/src/Network/Polkadot/Call.hs
@@ -15,6 +15,7 @@
 module Network.Polkadot.Call where
 
 import           Codec.Scale                   (Decode, Encode, Generic, decode)
+import           Control.Monad.Fail            (MonadFail)
 import           Data.List                     (findIndex)
 import           Data.Text                     (Text)
 import           Data.Word                     (Word8)

--- a/packages/polkadot/src/Network/Polkadot/Metadata/Type/Parser.hs
+++ b/packages/polkadot/src/Network/Polkadot/Metadata/Type/Parser.hs
@@ -20,7 +20,8 @@ module Network.Polkadot.Metadata.Type.Parser
   , sanitize
   , sanitizeM
   ) where
-
+  
+import           Control.Monad.Fail                               (MonadFail)
 import           Data.Text                                        (Text,
                                                                    intercalate,
                                                                    pack,

--- a/packages/provider/src/Network/Web3/Provider.hs
+++ b/packages/provider/src/Network/Web3/Provider.hs
@@ -22,6 +22,7 @@ module Network.Web3.Provider where
 import           Control.Concurrent.Async   (Async, async)
 import           Control.Exception          (Exception, try)
 import           Control.Monad.Catch        (MonadThrow)
+import           Control.Monad.Fail         (MonadFail)
 import           Control.Monad.IO.Class     (MonadIO (..))
 import           Control.Monad.State        (MonadState (..))
 import           Control.Monad.Trans.State  (StateT, evalStateT, withStateT)


### PR DESCRIPTION
Adds missing MonadFail imports needed to compile on ghc 8.6