### PR TITLE
Implement transaction timeouts.

### DIFF
--- a/packages/ethereum/src/Network/Ethereum/Account.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account.hs
@@ -40,13 +40,14 @@ module Network.Ethereum.Account
     , gasPrice
     , block
     , account
+    , timeout
 
     ) where
 
 import           Network.Ethereum.Account.Class    (Account (..))
 import           Network.Ethereum.Account.Default  (DefaultAccount)
 import           Network.Ethereum.Account.Internal (account, block, gasLimit,
-                                                    gasPrice, to, value,
+                                                    gasPrice, timeout, to, value,
                                                     withParam)
 import           Network.Ethereum.Account.LocalKey (LocalKey (..),
                                                     LocalKeyAccount)

--- a/packages/ethereum/src/Network/Ethereum/Account/Class.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account/Class.hs
@@ -17,6 +17,7 @@ module Network.Ethereum.Account.Class where
 
 import           Control.Monad.Trans              (MonadTrans)
 
+import           Data.ByteArray.HexString         (HexString)
 import           Data.Solidity.Abi                (AbiGet)
 import           Network.Ethereum.Api.Types       (TxReceipt)
 import           Network.Ethereum.Contract.Method (Method)
@@ -43,8 +44,8 @@ class MonadTrans t => Account a t | t -> a where
     send :: (JsonRpc m, Method args)
          => args
          -- ^ Contract method arguments
-         -> t m TxReceipt
-         -- ^ Receipt of sended transaction
+         -> t m (Either HexString TxReceipt)
+         -- ^ Receipt of the sent transaction, or transaction hash in case of a timeout
 
     -- | Call constant method of contract, like a 'read' command
     call :: (JsonRpc m, Method args, AbiGet result)

--- a/packages/ethereum/src/Network/Ethereum/Account/Default.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account/Default.hs
@@ -45,6 +45,7 @@ instance Account () DefaultAccount where
 
     send (args :: a) = do
         c <- getCall
+        timeout <- _timeout <$> get
         lift $ do
             accounts <- Eth.accounts
             let dat = selector (Proxy :: Proxy a) <> encode args
@@ -57,7 +58,7 @@ instance Account () DefaultAccount where
                     gasLimit <- Eth.estimateGas params
                     return $ params { callGas = Just gasLimit }
 
-            getReceipt =<< Eth.sendTransaction params'
+            getReceipt timeout =<< Eth.sendTransaction params'
 
     call (args :: a) = do
         c <- getCall

--- a/packages/ethereum/src/Network/Ethereum/Account/Internal.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account/Internal.hs
@@ -123,9 +123,6 @@ getCall = do
                  , callGasPrice = fromInteger <$> _gasPrice
                  }
 
-getTimeout :: MonadState (CallParam p) m => m (Maybe Int)
-getTimeout = _timeout <$> get
-
 getReceipt :: JsonRpc m => Maybe Int -> HexString -> m TxReceipt
 getReceipt mbtimeout tx = do
     mbreceipt <- Eth.getTransactionReceipt tx

--- a/packages/ethereum/src/Network/Ethereum/Account/LocalKey.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account/LocalKey.hs
@@ -82,7 +82,7 @@ instance Account LocalKey LocalKeyAccount where
 
         let packer = encodeTransaction params' (localKeyChainId _account)
             signed = signTransaction packer (localKeyPrivate _account)
-        lift $ getReceipt =<< Eth.sendRawTransaction signed
+        lift $ getReceipt _timeout =<< Eth.sendRawTransaction signed
 
     call (args :: a) = do
         CallParam{..} <- get

--- a/packages/ethereum/src/Network/Ethereum/Account/Personal.hs
+++ b/packages/ethereum/src/Network/Ethereum/Account/Personal.hs
@@ -70,12 +70,12 @@ instance Account Personal PersonalAccount where
                     gasLimit <- Eth.estimateGas params
                     return $ params { callGas = Just gasLimit }
 
-            getReceipt =<< Personal.sendTransaction params' (personalPassphrase _account)
+            getReceipt _timeout =<< Personal.sendTransaction params' (personalPassphrase _account)
 
     call (args :: a) = do
         s <- get
         case s of
-            CallParam _ _ _ _ block (Personal address _) -> do
+            CallParam _ _ _ _ block (Personal address _) _ -> do
                 c <- getCall
                 let dat = selector (Proxy :: Proxy a) <> encode args
                     params = c { callFrom = Just address, callData = Just $ BA.convert dat }

--- a/packages/ethereum/src/Network/Ethereum/Api/Types.hs
+++ b/packages/ethereum/src/Network/Ethereum/Api/Types.hs
@@ -18,6 +18,7 @@
 
 module Network.Ethereum.Api.Types where
 
+import           Control.Exception          (Exception)
 import           Data.Aeson                 (FromJSON (..), Options (fieldLabelModifier, omitNothingFields),
                                              ToJSON (..), Value (Bool, String),
                                              defaultOptions, object, (.=))
@@ -299,3 +300,11 @@ data BlockT tx = Block
 
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = over _head toLower . drop 5 }) ''BlockT)
+
+-- | Timeout exception.
+-- Thrown when a transaction is pending for longer than the timeout.
+-- Contains the transaction that timed out.
+data TransactionTimeout = TransactionTimeout HexString
+    deriving (Show, Eq)
+
+instance Exception TransactionTimeout

--- a/packages/ethereum/src/Network/Ethereum/Api/Types.hs
+++ b/packages/ethereum/src/Network/Ethereum/Api/Types.hs
@@ -18,7 +18,6 @@
 
 module Network.Ethereum.Api.Types where
 
-import           Control.Exception          (Exception)
 import           Data.Aeson                 (FromJSON (..), Options (fieldLabelModifier, omitNothingFields),
                                              ToJSON (..), Value (Bool, String),
                                              defaultOptions, object, (.=))
@@ -300,11 +299,3 @@ data BlockT tx = Block
 
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = over _head toLower . drop 5 }) ''BlockT)
-
--- | Timeout exception.
--- Thrown when a transaction is pending for longer than the timeout.
--- Contains the transaction that timed out.
-data TransactionTimeout = TransactionTimeout HexString
-    deriving (Show, Eq)
-
-instance Exception TransactionTimeout

--- a/packages/ethereum/src/Network/Ethereum/Contract.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract.hs
@@ -43,6 +43,12 @@ class Contract a where
 new :: (Account p t, JsonRpc m, Method a, Monad (t m))
     => a
     -- ^ Contract constructor
-    -> t m (Maybe Address)
-    -- ^ Address of deployed contract when transaction success
-new = fmap receiptContractAddress . safeSend safeConfirmations
+    -> t m (Either HexString (Maybe Address))
+    -- ^ Address of deployed contract when transaction success;
+    -- transaction hash in case of a timeout
+new = fmap (mapRight receiptContractAddress) . safeSend safeConfirmations
+  where
+    mapRight f either =
+        case either of
+            Left x -> Left x
+            Right y -> Right $ f y

--- a/packages/ethereum/src/Network/Ethereum/Contract.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract.hs
@@ -48,7 +48,7 @@ new :: (Account p t, JsonRpc m, Method a, Monad (t m))
     -- transaction hash in case of a timeout
 new = fmap (mapRight receiptContractAddress) . safeSend safeConfirmations
   where
-    mapRight f either =
-        case either of
+    mapRight f e =
+        case e of
             Left x -> Left x
             Right y -> Right $ f y

--- a/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
+++ b/packages/ethereum/src/Network/Ethereum/Contract/TH.hs
@@ -47,6 +47,7 @@ import           Control.Applicative              ((<|>))
 import           Control.Monad                    (replicateM, (<=<))
 import qualified Data.Aeson                       as Aeson (encode)
 import           Data.ByteArray                   (convert)
+import           Data.ByteArray.HexString         (HexString)
 import           Data.Char                        (toLower, toUpper)
 import qualified Data.Char                        as Char
 import           Data.Default                     (Default (..))
@@ -175,11 +176,12 @@ funWrapper c name dname args result = do
             Just [x] -> [t|$t $m $(typeFuncQ x)|]
             Just xs  -> let outs = fmap typeFuncQ xs
                          in  [t|$t $m $(foldl appT (tupleT (length xs)) outs)|]
+        receiptT = [t|$t $m (Either HexString TxReceipt)|]
 
     sequence [
         sigD name $ [t|
             (JsonRpc $m, Account $a $t, Functor ($t $m)) =>
-                $(arrowing $ inputT ++ [if c then outputT else [t|$t $m TxReceipt|]])
+                $(arrowing $ inputT ++ [if c then outputT else receiptT])
             |]
       , if c
             then funD' name (varP <$> vars) $ case result of


### PR DESCRIPTION
Fixes #120. I added a new exception type, because one from System.Timeout doesn't export a constructor. This also allowed attaching transaction data to the exception, which could be useful.