### PR TITLE
Add .cabal files to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 build/
 dist/
 docs/_build
-*.cabal
 stack.yaml.lock

--- a/packages/bignum/web3-bignum.cabal
+++ b/packages/bignum/web3-bignum.cabal
@@ -1,0 +1,64 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-bignum
+version:        1.0.0.0
+synopsis:       Fixed size big integers for Haskell Web3 library.
+description:    This package implements codec instances and other helper functions.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Data.BigNum
+  other-modules:
+      Paths_web3_bignum
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      base >4.11 && <4.15
+    , cereal >0.5 && <0.6
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , scale ==1.0.*
+    , wide-word >0.1 && <0.2
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Data.BigNum.Test.BigNumSpec
+      Data.BigNum
+      Paths_web3_bignum
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >4.11 && <4.15
+    , cereal >0.5 && <0.6
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , scale ==1.0.*
+    , wide-word >0.1 && <0.2
+  default-language: Haskell2010

--- a/packages/crypto/web3-crypto.cabal
+++ b/packages/crypto/web3-crypto.cabal
@@ -1,0 +1,105 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-crypto
+version:        1.0.0.0
+synopsis:       Cryptograhical primitives for Haskell Web3 library.
+description:    This package implements Web3 specific cryptography and helper functions.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    src/cbits/xxhash.h
+    src/cbits/xxhash.c
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Crypto.Bip39
+      Crypto.Ecdsa.Signature
+      Crypto.Ecdsa.Utils
+      Crypto.Ethereum
+      Crypto.Ethereum.Keyfile
+      Crypto.Ethereum.Signature
+      Crypto.Ethereum.Utils
+      Crypto.Random.HmacDrbg
+      Data.Digest.Blake2
+      Data.Digest.XXHash
+  other-modules:
+      Paths_web3_crypto
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  include-dirs:
+      src/cbits
+  c-sources:
+      src/cbits/xxhash.c
+  build-depends:
+      aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , containers >0.6 && <0.7
+    , cryptonite >0.22 && <0.30
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , text >1.2 && <1.3
+    , uuid-types >1.0 && <1.1
+    , vector >0.12 && <0.13
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Crypto.Ethereum.Test.KeyfileSpec
+      Crypto.Ethereum.Test.SignatureSpec
+      Crypto.Random.Test.HmacDrbgSpec
+      Data.Digest.Test.Blake2Spec
+      Data.Digest.Test.XXHashSpec
+      Crypto.Bip39
+      Crypto.Ecdsa.Signature
+      Crypto.Ecdsa.Utils
+      Crypto.Ethereum
+      Crypto.Ethereum.Keyfile
+      Crypto.Ethereum.Signature
+      Crypto.Ethereum.Utils
+      Crypto.Random.HmacDrbg
+      Data.Digest.Blake2
+      Data.Digest.XXHash
+      Paths_web3_crypto
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  include-dirs:
+      src/cbits
+  c-sources:
+      src/cbits/xxhash.c
+  build-depends:
+      aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , containers >0.6 && <0.7
+    , cryptonite >0.22 && <0.30
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , text >1.2 && <1.3
+    , uuid-types >1.0 && <1.1
+    , vector >0.12 && <0.13
+  default-language: Haskell2010

--- a/packages/ethereum/web3-ethereum.cabal
+++ b/packages/ethereum/web3-ethereum.cabal
@@ -1,0 +1,149 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-ethereum
+version:        1.0.0.0
+synopsis:       Ethereum support for Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.Ethereum
+      Network.Ethereum.Account
+      Network.Ethereum.Account.Class
+      Network.Ethereum.Account.Default
+      Network.Ethereum.Account.Internal
+      Network.Ethereum.Account.LocalKey
+      Network.Ethereum.Account.Personal
+      Network.Ethereum.Account.Safe
+      Network.Ethereum.Api.Eth
+      Network.Ethereum.Api.Net
+      Network.Ethereum.Api.Personal
+      Network.Ethereum.Api.Types
+      Network.Ethereum.Api.Web3
+      Network.Ethereum.Chain
+      Network.Ethereum.Contract
+      Network.Ethereum.Contract.Event
+      Network.Ethereum.Contract.Event.Common
+      Network.Ethereum.Contract.Event.MultiFilter
+      Network.Ethereum.Contract.Event.SingleFilter
+      Network.Ethereum.Contract.Method
+      Network.Ethereum.Contract.TH
+      Network.Ethereum.Ens
+      Network.Ethereum.Ens.PublicResolver
+      Network.Ethereum.Ens.Registry
+      Network.Ethereum.Transaction
+      Network.Ethereum.Unit
+  other-modules:
+      Paths_web3_ethereum
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      OneTuple >0.2 && <0.3
+    , aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , data-default >0.7 && <0.8
+    , exceptions >0.8 && <0.11
+    , generics-sop >0.3 && <0.6
+    , jsonrpc-tinyclient ==1.0.*
+    , machines >0.6 && <0.8
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , microlens-aeson >2.2 && <2.4
+    , mtl >2.2 && <2.3
+    , relapse >=1.0 && <2.0
+    , tagged >0.8 && <0.9
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , transformers >0.5 && <0.6
+    , vinyl >0.5 && <0.14
+    , web3-crypto ==1.0.*
+    , web3-solidity ==1.0.*
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Network.Ethereum.Test.EventSpec
+      Network.Ethereum.Test.MethodDumpSpec
+      Network.Ethereum.Test.THSpec
+      Network.Ethereum.Test.TransactionSpec
+      Network.Ethereum
+      Network.Ethereum.Account
+      Network.Ethereum.Account.Class
+      Network.Ethereum.Account.Default
+      Network.Ethereum.Account.Internal
+      Network.Ethereum.Account.LocalKey
+      Network.Ethereum.Account.Personal
+      Network.Ethereum.Account.Safe
+      Network.Ethereum.Api.Eth
+      Network.Ethereum.Api.Net
+      Network.Ethereum.Api.Personal
+      Network.Ethereum.Api.Types
+      Network.Ethereum.Api.Web3
+      Network.Ethereum.Chain
+      Network.Ethereum.Contract
+      Network.Ethereum.Contract.Event
+      Network.Ethereum.Contract.Event.Common
+      Network.Ethereum.Contract.Event.MultiFilter
+      Network.Ethereum.Contract.Event.SingleFilter
+      Network.Ethereum.Contract.Method
+      Network.Ethereum.Contract.TH
+      Network.Ethereum.Ens
+      Network.Ethereum.Ens.PublicResolver
+      Network.Ethereum.Ens.Registry
+      Network.Ethereum.Transaction
+      Network.Ethereum.Unit
+      Paths_web3_ethereum
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      OneTuple >0.2 && <0.3
+    , aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , data-default >0.7 && <0.8
+    , exceptions >0.8 && <0.11
+    , generics-sop >0.3 && <0.6
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , jsonrpc-tinyclient ==1.0.*
+    , machines >0.6 && <0.8
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , microlens-aeson >2.2 && <2.4
+    , mtl >2.2 && <2.3
+    , relapse >=1.0 && <2.0
+    , tagged >0.8 && <0.9
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , transformers >0.5 && <0.6
+    , vinyl >0.5 && <0.14
+    , web3-crypto ==1.0.*
+    , web3-solidity ==1.0.*
+  default-language: Haskell2010

--- a/packages/hexstring/memory-hexstring.cabal
+++ b/packages/hexstring/memory-hexstring.cabal
@@ -1,0 +1,44 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           memory-hexstring
+version:        1.0.0.0
+synopsis:       Hex-string type for Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Data.ByteArray.HexString
+      Data.ByteArray.HexString.Convert
+      Data.ByteArray.HexString.Internal
+      Data.ByteArray.HexString.TH
+  other-modules:
+      Paths_memory_hexstring
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , memory >0.14 && <0.16
+    , scale ==1.0.*
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+  default-language: Haskell2010

--- a/packages/ipfs/web3-ipfs.cabal
+++ b/packages/ipfs/web3-ipfs.cabal
@@ -1,0 +1,68 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-ipfs
+version:        1.0.0.0
+synopsis:       IPFS support for Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.Ipfs.Api.Bitswap
+      Network.Ipfs.Api.Block
+      Network.Ipfs.Api.Bootstrap
+      Network.Ipfs.Api.Cid
+      Network.Ipfs.Api.Config
+      Network.Ipfs.Api.Core
+      Network.Ipfs.Api.Dag
+      Network.Ipfs.Api.Dht
+      Network.Ipfs.Api.Files
+      Network.Ipfs.Api.Internal
+      Network.Ipfs.Api.Internal.Call
+      Network.Ipfs.Api.Internal.Stream
+      Network.Ipfs.Api.Key
+      Network.Ipfs.Api.Log
+      Network.Ipfs.Api.Object
+      Network.Ipfs.Api.Pin
+      Network.Ipfs.Api.Pubsub
+      Network.Ipfs.Api.Repo
+      Network.Ipfs.Api.Stats
+      Network.Ipfs.Api.Swarm
+      Network.Ipfs.Api.Types
+      Network.Ipfs.Api.Types.Stream
+      Network.Ipfs.Client
+  other-modules:
+      Paths_web3_ipfs
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , http-client >0.5 && <0.7
+    , http-media >0.6 && <0.8.1
+    , http-types >0.11 && <0.14
+    , mtl >2.2 && <2.3
+    , servant >0.12 && <0.19
+    , servant-client >0.12 && <0.19
+    , tar >0.4 && <0.6
+    , text >1.2 && <1.3
+    , unordered-containers >0.1 && <0.3
+  default-language: Haskell2010

--- a/packages/jsonrpc/jsonrpc-tinyclient.cabal
+++ b/packages/jsonrpc/jsonrpc-tinyclient.cabal
@@ -1,0 +1,44 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           jsonrpc-tinyclient
+version:        1.0.0.0
+synopsis:       Tiny JSON-RPC client for Haskell Web3 library.
+description:    Minimalistic JSON-RPC client, inspired by haxr library.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.JsonRpc.TinyClient
+  other-modules:
+      Paths_jsonrpc_tinyclient
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , bytestring >0.10 && <0.11
+    , exceptions >0.8 && <0.11
+    , http-client >0.5 && <0.7
+    , http-client-tls >0.3 && <0.4
+    , mtl >2.2 && <2.3
+    , random >1.0 && <1.3
+    , text >1.2 && <1.3
+    , websockets >0.10 && <0.13
+  default-language: Haskell2010

--- a/packages/polkadot/web3-polkadot.cabal
+++ b/packages/polkadot/web3-polkadot.cabal
@@ -1,0 +1,176 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-polkadot
+version:        1.0.0.0
+synopsis:       Polkadot support for Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.Polkadot
+      Network.Polkadot.Account
+      Network.Polkadot.Call
+      Network.Polkadot.Crypto
+      Network.Polkadot.Extrinsic
+      Network.Polkadot.Extrinsic.Era
+      Network.Polkadot.Extrinsic.Payload
+      Network.Polkadot.Extrinsic.SignedExtension
+      Network.Polkadot.Extrinsic.SignedExtension.System
+      Network.Polkadot.Extrinsic.SignedExtension.TransactionPayment
+      Network.Polkadot.Extrinsic.Unchecked
+      Network.Polkadot.Metadata
+      Network.Polkadot.Metadata.MagicNumber
+      Network.Polkadot.Metadata.Type
+      Network.Polkadot.Metadata.Type.Ast
+      Network.Polkadot.Metadata.Type.Discovery
+      Network.Polkadot.Metadata.Type.Parser
+      Network.Polkadot.Metadata.Type.ParserCombinators
+      Network.Polkadot.Metadata.V10
+      Network.Polkadot.Metadata.V11
+      Network.Polkadot.Metadata.V12
+      Network.Polkadot.Metadata.V13
+      Network.Polkadot.Metadata.V9
+      Network.Polkadot.Primitives
+      Network.Polkadot.Query
+      Network.Polkadot.Rpc.Account
+      Network.Polkadot.Rpc.Author
+      Network.Polkadot.Rpc.Babe
+      Network.Polkadot.Rpc.Chain
+      Network.Polkadot.Rpc.Childstate
+      Network.Polkadot.Rpc.Contracts
+      Network.Polkadot.Rpc.Engine
+      Network.Polkadot.Rpc.Grandpa
+      Network.Polkadot.Rpc.Offchain
+      Network.Polkadot.Rpc.Payment
+      Network.Polkadot.Rpc.Rpc
+      Network.Polkadot.Rpc.State
+      Network.Polkadot.Rpc.System
+      Network.Polkadot.Rpc.Types
+      Network.Polkadot.Storage
+      Network.Polkadot.Storage.Key
+  other-modules:
+      Paths_web3_polkadot
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      aeson >1.2 && <1.6
+    , animalcase >0.1 && <0.2
+    , base >4.11 && <4.15
+    , base58-bytestring ==0.1.*
+    , bytestring >0.10 && <0.11
+    , containers >0.6 && <0.7
+    , cryptonite >0.22 && <0.30
+    , generics-sop >0.3 && <0.6
+    , jsonrpc-tinyclient ==1.0.*
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , microlens-mtl >0.2 && <0.3
+    , microlens-th >0.4 && <0.5
+    , mtl >2.2 && <2.3
+    , parsec >3.0 && <3.2
+    , scale ==1.0.*
+    , text >1.2 && <1.3
+    , web3-bignum ==1.0.*
+    , web3-crypto ==1.0.*
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Network.Polkadot.Test.AccountSpec
+      Network.Polkadot.Test.ExtrinsicSpec
+      Network.Polkadot.Test.MetadataSpec
+      Network.Polkadot.Test.StorageSpec
+      Network.Polkadot
+      Network.Polkadot.Account
+      Network.Polkadot.Call
+      Network.Polkadot.Crypto
+      Network.Polkadot.Extrinsic
+      Network.Polkadot.Extrinsic.Era
+      Network.Polkadot.Extrinsic.Payload
+      Network.Polkadot.Extrinsic.SignedExtension
+      Network.Polkadot.Extrinsic.SignedExtension.System
+      Network.Polkadot.Extrinsic.SignedExtension.TransactionPayment
+      Network.Polkadot.Extrinsic.Unchecked
+      Network.Polkadot.Metadata
+      Network.Polkadot.Metadata.MagicNumber
+      Network.Polkadot.Metadata.Type
+      Network.Polkadot.Metadata.Type.Ast
+      Network.Polkadot.Metadata.Type.Discovery
+      Network.Polkadot.Metadata.Type.Parser
+      Network.Polkadot.Metadata.Type.ParserCombinators
+      Network.Polkadot.Metadata.V10
+      Network.Polkadot.Metadata.V11
+      Network.Polkadot.Metadata.V12
+      Network.Polkadot.Metadata.V13
+      Network.Polkadot.Metadata.V9
+      Network.Polkadot.Primitives
+      Network.Polkadot.Query
+      Network.Polkadot.Rpc.Account
+      Network.Polkadot.Rpc.Author
+      Network.Polkadot.Rpc.Babe
+      Network.Polkadot.Rpc.Chain
+      Network.Polkadot.Rpc.Childstate
+      Network.Polkadot.Rpc.Contracts
+      Network.Polkadot.Rpc.Engine
+      Network.Polkadot.Rpc.Grandpa
+      Network.Polkadot.Rpc.Offchain
+      Network.Polkadot.Rpc.Payment
+      Network.Polkadot.Rpc.Rpc
+      Network.Polkadot.Rpc.State
+      Network.Polkadot.Rpc.System
+      Network.Polkadot.Rpc.Types
+      Network.Polkadot.Storage
+      Network.Polkadot.Storage.Key
+      Paths_web3_polkadot
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson >1.2 && <1.6
+    , animalcase >0.1 && <0.2
+    , base >4.11 && <4.15
+    , base58-bytestring ==0.1.*
+    , bytestring >0.10 && <0.11
+    , containers >0.6 && <0.7
+    , cryptonite >0.22 && <0.30
+    , generics-sop >0.3 && <0.6
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , hspec-expectations-json >=1.0.0 && <1.1
+    , jsonrpc-tinyclient ==1.0.*
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , microlens-mtl >0.2 && <0.3
+    , microlens-th >0.4 && <0.5
+    , mtl >2.2 && <2.3
+    , parsec >3.0 && <3.2
+    , scale ==1.0.*
+    , text >1.2 && <1.3
+    , web3-bignum ==1.0.*
+    , web3-crypto ==1.0.*
+  default-language: Haskell2010

--- a/packages/provider/web3-provider.cabal
+++ b/packages/provider/web3-provider.cabal
@@ -1,0 +1,45 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-provider
+version:        1.0.0.0
+synopsis:       Node connection provider for Haskell Web3 library.
+description:    This package contains general Web3 node adapters and connection helpers.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.Web3.Provider
+  other-modules:
+      Paths_web3_provider
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      async >2.1 && <2.3
+    , base >4.11 && <4.15
+    , data-default >0.7 && <0.8
+    , exceptions >0.8 && <0.11
+    , http-client >0.5 && <0.7
+    , jsonrpc-tinyclient ==1.0.*
+    , mtl >2.2 && <2.3
+    , network >2.5 && <3.2
+    , text >1.2 && <1.3
+    , transformers >0.5 && <0.6
+    , websockets >0.10 && <0.13
+  default-language: Haskell2010

--- a/packages/scale/scale.cabal
+++ b/packages/scale/scale.cabal
@@ -1,0 +1,88 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           scale
+version:        1.0.0.0
+synopsis:       SCALE v2.0 codec for Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Codec.Scale
+      Codec.Scale.Class
+      Codec.Scale.Compact
+      Codec.Scale.Core
+      Codec.Scale.Generic
+      Codec.Scale.SingletonEnum
+      Codec.Scale.Skip
+      Codec.Scale.TH
+  other-modules:
+      Paths_scale
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      base >4.11 && <4.15
+    , bitvec >1.0 && <2.0
+    , bytestring >0.10 && <0.11
+    , cereal >0.5 && <0.6
+    , data-default >0.7 && <0.8
+    , generics-sop >0.3 && <0.6
+    , memory >0.14 && <0.16
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , vector >0.12 && <0.13
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Codec.Scale.Test.CoreSpec
+      Codec.Scale.Test.SingleFieldStructSpec
+      Codec.Scale.Test.SkipSpec
+      Codec.Scale
+      Codec.Scale.Class
+      Codec.Scale.Compact
+      Codec.Scale.Core
+      Codec.Scale.Generic
+      Codec.Scale.SingletonEnum
+      Codec.Scale.Skip
+      Codec.Scale.TH
+      Paths_scale
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >4.11 && <4.15
+    , bitvec >1.0 && <2.0
+    , bytestring >0.10 && <0.11
+    , cereal >0.5 && <0.6
+    , data-default >0.7 && <0.8
+    , generics-sop >0.3 && <0.6
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , memory >0.14 && <0.16
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , vector >0.12 && <0.13
+  default-language: Haskell2010

--- a/packages/solidity/web3-solidity.cabal
+++ b/packages/solidity/web3-solidity.cabal
@@ -1,0 +1,117 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3-solidity
+version:        1.0.0.0
+synopsis:       Solidity language for Haskell Web3 library.
+description:    This package contains Solidity parsec-based parser and primitive types.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Data.Solidity.Abi
+      Data.Solidity.Abi.Codec
+      Data.Solidity.Abi.Generic
+      Data.Solidity.Event
+      Data.Solidity.Event.Internal
+      Data.Solidity.Prim
+      Data.Solidity.Prim.Address
+      Data.Solidity.Prim.Bool
+      Data.Solidity.Prim.Bytes
+      Data.Solidity.Prim.Int
+      Data.Solidity.Prim.List
+      Data.Solidity.Prim.String
+      Data.Solidity.Prim.Tagged
+      Data.Solidity.Prim.Tuple
+      Data.Solidity.Prim.Tuple.TH
+      Language.Solidity.Abi
+  other-modules:
+      Paths_web3_solidity
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      OneTuple >0.2 && <0.3
+    , aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , basement >0.0 && <0.1
+    , bytestring >0.10 && <0.11
+    , cereal >0.5 && <0.6
+    , data-default >0.7 && <0.8
+    , generics-sop >0.3 && <0.6
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , parsec >3.1 && <3.2
+    , tagged >0.8 && <0.9
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , web3-crypto ==1.0.*
+  default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Data.Solidity.Test.AddressSpec
+      Data.Solidity.Test.EncodingSpec
+      Data.Solidity.Test.IntSpec
+      Language.Solidity.Test.AbiSpec
+      Data.Solidity.Abi
+      Data.Solidity.Abi.Codec
+      Data.Solidity.Abi.Generic
+      Data.Solidity.Event
+      Data.Solidity.Event.Internal
+      Data.Solidity.Prim
+      Data.Solidity.Prim.Address
+      Data.Solidity.Prim.Bool
+      Data.Solidity.Prim.Bytes
+      Data.Solidity.Prim.Int
+      Data.Solidity.Prim.List
+      Data.Solidity.Prim.String
+      Data.Solidity.Prim.Tagged
+      Data.Solidity.Prim.Tuple
+      Data.Solidity.Prim.Tuple.TH
+      Language.Solidity.Abi
+      Paths_web3_solidity
+  hs-source-dirs:
+      tests
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      OneTuple >0.2 && <0.3
+    , aeson >1.2 && <1.6
+    , base >4.11 && <4.15
+    , basement >0.0 && <0.1
+    , bytestring >0.10 && <0.11
+    , cereal >0.5 && <0.6
+    , data-default >0.7 && <0.8
+    , generics-sop >0.3 && <0.6
+    , hspec >=2.4.4 && <2.8
+    , hspec-contrib >=0.4.0 && <0.6
+    , hspec-discover >=2.4.4 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , memory >0.14 && <0.16
+    , memory-hexstring ==1.0.*
+    , microlens >0.4 && <0.5
+    , parsec >3.1 && <3.2
+    , tagged >0.8 && <0.9
+    , template-haskell >2.11 && <2.17
+    , text >1.2 && <1.3
+    , web3-crypto ==1.0.*
+  default-language: Haskell2010

--- a/packages/web3/web3.cabal
+++ b/packages/web3/web3.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           web3
+version:        1.0.0.0
+synopsis:       Haskell Web3 library.
+description:    Client library for Third Generation of Web.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+library
+  exposed-modules:
+      Network.Web3
+  other-modules:
+      Paths_web3
+  hs-source-dirs:
+      src
+  ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
+  build-depends:
+      base >4.11 && <4.15
+    , web3-ethereum ==1.0.*
+    , web3-polkadot ==1.0.*
+    , web3-provider ==1.0.*
+  default-language: Haskell2010


### PR DESCRIPTION
This is current best practice. It also allows me to use the repo directly in `cabal.project`.

https://docs.haskellstack.org/en/stable/stack_yaml_vs_cabal_package_file/#should-i-check-in-generated-cabal-files
https://github.com/commercialhaskell/stack/issues/5210