### PR TITLE
Add support for Solidity error declarations.

### DIFF
--- a/packages/solidity/src/Language/Solidity/Abi.hs
+++ b/packages/solidity/src/Language/Solidity/Abi.hs
@@ -346,6 +346,7 @@ parseSolidityFunctionArgType (FunctionArg _ typ mcmps) = case mcmps of
     case typ of
         "tuple"   -> return tpl
         "tuple[]" -> return $ SolidityArray tpl
+        _         -> error $ "Unexpected type " ++ T.unpack typ ++ " - expected tuple or tuple[]"
 
 parseSolidityEventArgType :: EventArg -> Either ParseError SolidityType
 parseSolidityEventArgType (EventArg _ typ _) = parse solidityTypeParser "Solidity" typ


### PR DESCRIPTION
Correctly encode and decode tuple[] data types, for example, the return
type of getMessages() below:
struct Message {
    address sender;
    string text;
}
function getMessages() view public returns (Message[] memory)

You can find a self-contained test case for this at the URL below. The contract is already deployed and tokens to pay fees are already there, so all you need to do is run the program.

http://45.63.90.8/~blackh/songbird.tar.gz

To build this test case:

1. expand the archive
2. cd songbird/
3. check out hs-web3
4. stack build

You can view the contract and see what the expected output of getMessages() is here:
https://songbird-explorer.flare.network/address/0x50d9799479E42f148311bFf4e00e49F60f01484f/read-contract