### PR TITLE
Version numbers

### DIFF
--- a/examples/erc20/example-erc20.cabal
+++ b/examples/erc20/example-erc20.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-erc20
+version:        0.0.0.0
+synopsis:       ERC20 token example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-erc20
+  main-is: Main.hs
+  other-modules:
+      ERC20
+      Paths_example_erc20
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , data-default
+    , microlens
+    , text
+    , web3
+    , web3-ethereum
+  default-language: Haskell2010

--- a/examples/polkadot/example-polkadot.cabal
+++ b/examples/polkadot/example-polkadot.cabal
@@ -1,0 +1,34 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-polkadot
+version:        0.0.0.0
+synopsis:       Polkadot API example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-polkadot
+  main-is: Main.hs
+  other-modules:
+      Paths_example_polkadot
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , web3-polkadot
+    , web3-provider
+  default-language: Haskell2010

--- a/examples/scale/example-scale.cabal
+++ b/examples/scale/example-scale.cabal
@@ -1,0 +1,35 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-scale
+version:        0.0.0.0
+synopsis:       SCALE codec example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-scale
+  main-is: Main.hs
+  other-modules:
+      Paths_example_scale
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , generics-sop
+    , memory-hexstring
+    , scale
+  default-language: Haskell2010

--- a/packages/bignum/package.yaml
+++ b/packages/bignum/package.yaml
@@ -11,9 +11,9 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - scale                >=1.0 && <1.1
-- memory               >0.14 && <0.16
+- memory               >0.14 && <0.17
 - memory-hexstring     >=1.0 && <1.1
 - cereal               >0.5  && <0.6
 - wide-word            >0.1  && <0.2

--- a/packages/bignum/package.yaml
+++ b/packages/bignum/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-bignum
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Fixed size big integers for Haskell Web3 library.
 description:         This package implements codec instances and other helper functions.
 github:              "airalab/hs-web3"

--- a/packages/bignum/web3-bignum.cabal
+++ b/packages/bignum/web3-bignum.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-bignum
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Fixed size big integers for Haskell Web3 library.
 description:    This package implements codec instances and other helper functions.
 category:       Network

--- a/packages/bignum/web3-bignum.cabal
+++ b/packages/bignum/web3-bignum.cabal
@@ -31,9 +31,9 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.15
+      base >4.11 && <4.16
     , cereal >0.5 && <0.6
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , scale ==1.0.*
     , wide-word >0.1 && <0.2
@@ -51,13 +51,13 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >4.11 && <4.15
+      base >4.11 && <4.16
     , cereal >0.5 && <0.6
     , hspec >=2.4.4 && <2.8
     , hspec-contrib >=0.4.0 && <0.6
     , hspec-discover >=2.4.4 && <2.8
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , scale ==1.0.*
     , wide-word >0.1 && <0.2

--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -15,10 +15,10 @@ extra-source-files:
 - src/cbits/xxhash.c
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
-- memory               >0.14 && <0.16
+- aeson                >1.2  && <2.1
+- memory               >0.14 && <0.17
 - vector               >0.12 && <0.13
 - containers           >0.6  && <0.7
 - uuid-types           >1.0  && <1.1

--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-crypto
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Cryptograhical primitives for Haskell Web3 library.
 description:         This package implements Web3 specific cryptography and helper functions.
 github:              "airalab/hs-web3"

--- a/packages/crypto/web3-crypto.cabal
+++ b/packages/crypto/web3-crypto.cabal
@@ -47,12 +47,12 @@ library
   c-sources:
       src/cbits/xxhash.c
   build-depends:
-      aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , containers >0.6 && <0.7
     , cryptonite >0.22 && <0.30
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , text >1.2 && <1.3
     , uuid-types >1.0 && <1.1
@@ -88,8 +88,8 @@ test-suite tests
   c-sources:
       src/cbits/xxhash.c
   build-depends:
-      aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , containers >0.6 && <0.7
     , cryptonite >0.22 && <0.30
@@ -97,7 +97,7 @@ test-suite tests
     , hspec-contrib >=0.4.0 && <0.6
     , hspec-discover >=2.4.4 && <2.8
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , text >1.2 && <1.3
     , uuid-types >1.0 && <1.1

--- a/packages/crypto/web3-crypto.cabal
+++ b/packages/crypto/web3-crypto.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-crypto
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Cryptograhical primitives for Haskell Web3 library.
 description:    This package implements Web3 specific cryptography and helper functions.
 category:       Network

--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -11,14 +11,14 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
 - vinyl                >0.5  && <0.14
-- aeson                >1.2  && <1.6
+- aeson                >1.2  && <2.1
 - tagged               >0.8  && <0.9
-- memory               >0.14 && <0.16
+- memory               >0.14 && <0.17
 - relapse              >=1.0 && <2.0
-- OneTuple             >0.2  && <0.3
+- OneTuple             >0.2  && <0.4
 - machines             >0.6  && <0.8
 - microlens            >0.4  && <0.5
 - bytestring           >0.10 && <0.11
@@ -26,8 +26,8 @@ dependencies:
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
 - transformers         >0.5  && <0.6
-- microlens-aeson      >2.2  && <2.4
-- template-haskell     >2.11 && <2.17
+- microlens-aeson      >2.2  && <2.5
+- template-haskell     >2.11 && <2.18
 - mtl                  >2.2  && <2.3
 - web3-crypto          >=1.0 && <1.1
 - web3-solidity        >=1.0 && <1.1

--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-ethereum
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Ethereum support for Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/ethereum/web3-ethereum.cabal
+++ b/packages/ethereum/web3-ethereum.cabal
@@ -56,23 +56,23 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      OneTuple >0.2 && <0.3
-    , aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      OneTuple >0.2 && <0.4
+    , aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
     , generics-sop >0.3 && <0.6
     , jsonrpc-tinyclient ==1.0.*
     , machines >0.6 && <0.8
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
-    , microlens-aeson >2.2 && <2.4
+    , microlens-aeson >2.2 && <2.5
     , mtl >2.2 && <2.3
     , relapse >=1.0 && <2.0
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , transformers >0.5 && <0.6
     , vinyl >0.5 && <0.14
@@ -120,9 +120,9 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      OneTuple >0.2 && <0.3
-    , aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      OneTuple >0.2 && <0.4
+    , aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
@@ -133,14 +133,14 @@ test-suite tests
     , hspec-expectations >=0.8.2 && <0.9
     , jsonrpc-tinyclient ==1.0.*
     , machines >0.6 && <0.8
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
-    , microlens-aeson >2.2 && <2.4
+    , microlens-aeson >2.2 && <2.5
     , mtl >2.2 && <2.3
     , relapse >=1.0 && <2.0
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , transformers >0.5 && <0.6
     , vinyl >0.5 && <0.14

--- a/packages/ethereum/web3-ethereum.cabal
+++ b/packages/ethereum/web3-ethereum.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-ethereum
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Ethereum support for Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/hexstring/memory-hexstring.cabal
+++ b/packages/hexstring/memory-hexstring.cabal
@@ -34,11 +34,11 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , scale ==1.0.*
-    , template-haskell >2.11 && <2.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
   default-language: Haskell2010

--- a/packages/hexstring/memory-hexstring.cabal
+++ b/packages/hexstring/memory-hexstring.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           memory-hexstring
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Hex-string type for Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/hexstring/package.yaml
+++ b/packages/hexstring/package.yaml
@@ -1,5 +1,5 @@
 name:                memory-hexstring
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Hex-string type for Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/hexstring/package.yaml
+++ b/packages/hexstring/package.yaml
@@ -11,12 +11,12 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
-- memory               >0.14 && <0.16
+- aeson                >1.2  && <2.1
+- memory               >0.14 && <0.17
 - bytestring           >0.10 && <0.11
-- template-haskell     >2.11 && <2.17
+- template-haskell     >2.11 && <2.18
 - scale                >=1.0 && <1.1
 
 ghc-options:

--- a/packages/ipfs/package.yaml
+++ b/packages/ipfs/package.yaml
@@ -11,17 +11,17 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - mtl                  >2.2  && <2.3
 - tar                  >0.4  && <0.6  
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
-- servant              >0.12 && <0.19
+- aeson                >1.2  && <2.1
+- servant              >0.12 && <0.20
 - http-media           >0.6  && <0.8.1
 - bytestring           >0.10 && <0.11
 - http-types           >0.11 && <0.14 
-- http-client          >0.5  && <0.7
-- servant-client       >0.12 && <0.19
+- http-client          >0.5  && <0.8
+- servant-client       >0.12 && <0.20
 - unordered-containers >0.1  && <0.3 
 
 ghc-options:

--- a/packages/ipfs/package.yaml
+++ b/packages/ipfs/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-ipfs
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            IPFS support for Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/ipfs/src/Network/Ipfs/Api/Types.hs
+++ b/packages/ipfs/src/Network/Ipfs/Api/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -21,9 +22,14 @@ module Network.Ipfs.Api.Types where
 import           Control.Arrow              (left)
 import           Control.Monad
 import           Data.Aeson
+#if __GLASGOW_HASKELL__ >= 900
+import qualified Data.Aeson.KeyMap          as H
+#endif
 import           Data.ByteString.Lazy       (toStrict)
 import qualified Data.ByteString.Lazy.Char8 ()
+#if __GLASGOW_HASKELL__ < 900
 import qualified Data.HashMap.Strict        as H
+#endif
 import           Data.Int
 import           Data.Text                  (Text)
 import qualified Data.Text.Encoding         as TextS

--- a/packages/ipfs/web3-ipfs.cabal
+++ b/packages/ipfs/web3-ipfs.cabal
@@ -53,15 +53,15 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
-    , http-client >0.5 && <0.7
+    , http-client >0.5 && <0.8
     , http-media >0.6 && <0.8.1
     , http-types >0.11 && <0.14
     , mtl >2.2 && <2.3
-    , servant >0.12 && <0.19
-    , servant-client >0.12 && <0.19
+    , servant >0.12 && <0.20
+    , servant-client >0.12 && <0.20
     , tar >0.4 && <0.6
     , text >1.2 && <1.3
     , unordered-containers >0.1 && <0.3

--- a/packages/ipfs/web3-ipfs.cabal
+++ b/packages/ipfs/web3-ipfs.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-ipfs
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       IPFS support for Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/jsonrpc/jsonrpc-tinyclient.cabal
+++ b/packages/jsonrpc/jsonrpc-tinyclient.cabal
@@ -31,11 +31,11 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , exceptions >0.8 && <0.11
-    , http-client >0.5 && <0.7
+    , http-client >0.5 && <0.8
     , http-client-tls >0.3 && <0.4
     , mtl >2.2 && <2.3
     , random >1.0 && <1.3

--- a/packages/jsonrpc/jsonrpc-tinyclient.cabal
+++ b/packages/jsonrpc/jsonrpc-tinyclient.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           jsonrpc-tinyclient
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Tiny JSON-RPC client for Haskell Web3 library.
 description:    Minimalistic JSON-RPC client, inspired by haxr library.
 category:       Network

--- a/packages/jsonrpc/package.yaml
+++ b/packages/jsonrpc/package.yaml
@@ -11,14 +11,14 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
+- aeson                >1.2  && <2.1
 - random               >1.0  && <1.3
 - bytestring           >0.10 && <0.11
 - exceptions           >0.8  && <0.11
 - websockets           >0.10 && <0.13
-- http-client          >0.5  && <0.7
+- http-client          >0.5  && <0.8
 - http-client-tls      >0.3  && <0.4
 - mtl                  >2.2  && <2.3
 

--- a/packages/jsonrpc/package.yaml
+++ b/packages/jsonrpc/package.yaml
@@ -1,5 +1,5 @@
 name:                jsonrpc-tinyclient
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Tiny JSON-RPC client for Haskell Web3 library.
 description:         Minimalistic JSON-RPC client, inspired by haxr library.
 github:              "airalab/hs-web3"

--- a/packages/polkadot/package.yaml
+++ b/packages/polkadot/package.yaml
@@ -12,12 +12,12 @@ category:            Network
 
 dependencies:
 - mtl                  >2.2  && <2.3
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
+- aeson                >1.2  && <2.1
 - scale                >=1.0 && <1.1
 - parsec               >3.0  && <3.2
-- memory               >0.14 && <0.16
+- memory               >0.14 && <0.17
 - microlens            >0.4  && <0.5
 - containers           >0.6  && <0.7
 - cryptonite           >0.22 && <0.30

--- a/packages/polkadot/package.yaml
+++ b/packages/polkadot/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-polkadot
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Polkadot support for Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/polkadot/web3-polkadot.cabal
+++ b/packages/polkadot/web3-polkadot.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-polkadot
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Polkadot support for Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/polkadot/web3-polkadot.cabal
+++ b/packages/polkadot/web3-polkadot.cabal
@@ -71,16 +71,16 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      aeson >1.2 && <1.6
+      aeson >1.2 && <2.1
     , animalcase >0.1 && <0.2
-    , base >4.11 && <4.15
+    , base >4.11 && <4.16
     , base58-bytestring ==0.1.*
     , bytestring >0.10 && <0.11
     , containers >0.6 && <0.7
     , cryptonite >0.22 && <0.30
     , generics-sop >0.3 && <0.6
     , jsonrpc-tinyclient ==1.0.*
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , microlens-mtl >0.2 && <0.3
@@ -148,9 +148,9 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >1.2 && <1.6
+      aeson >1.2 && <2.1
     , animalcase >0.1 && <0.2
-    , base >4.11 && <4.15
+    , base >4.11 && <4.16
     , base58-bytestring ==0.1.*
     , bytestring >0.10 && <0.11
     , containers >0.6 && <0.7
@@ -162,7 +162,7 @@ test-suite tests
     , hspec-expectations >=0.8.2 && <0.9
     , hspec-expectations-json >=1.0.0 && <1.1
     , jsonrpc-tinyclient ==1.0.*
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , microlens-mtl >0.2 && <0.3

--- a/packages/provider/package.yaml
+++ b/packages/provider/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-provider
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Node connection provider for Haskell Web3 library.
 description:         This package contains general Web3 node adapters and connection helpers.
 github:              "airalab/hs-web3"

--- a/packages/provider/package.yaml
+++ b/packages/provider/package.yaml
@@ -11,14 +11,14 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - mtl                  >2.2  && <2.3
 - text                 >1.2  && <1.3
 - async                >2.1  && <2.3
 - network              >2.5  && <3.2
 - websockets           >0.10 && <0.13
 - exceptions           >0.8  && <0.11
-- http-client          >0.5  && <0.7
+- http-client          >0.5  && <0.8
 - data-default         >0.7  && <0.8
 - transformers         >0.5  && <0.6
 - jsonrpc-tinyclient   >=1.0 && <1.1

--- a/packages/provider/web3-provider.cabal
+++ b/packages/provider/web3-provider.cabal
@@ -32,10 +32,10 @@ library
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
       async >2.1 && <2.3
-    , base >4.11 && <4.15
+    , base >4.11 && <4.16
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
-    , http-client >0.5 && <0.7
+    , http-client >0.5 && <0.8
     , jsonrpc-tinyclient ==1.0.*
     , mtl >2.2 && <2.3
     , network >2.5 && <3.2

--- a/packages/provider/web3-provider.cabal
+++ b/packages/provider/web3-provider.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-provider
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Node connection provider for Haskell Web3 library.
 description:    This package contains general Web3 node adapters and connection helpers.
 category:       Network

--- a/packages/scale/package.yaml
+++ b/packages/scale/package.yaml
@@ -1,5 +1,5 @@
 name:                scale
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            SCALE v2.0 codec for Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/scale/package.yaml
+++ b/packages/scale/package.yaml
@@ -11,16 +11,16 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
 - cereal               >0.5  && <0.6
 - bitvec               >1.0  && <2.0
 - vector               >0.12 && <0.13
-- memory               >0.14 && <0.16
+- memory               >0.14 && <0.17
 - bytestring           >0.10 && <0.11
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.17
+- template-haskell     >2.11 && <2.18
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/scale/scale.cabal
+++ b/packages/scale/scale.cabal
@@ -38,14 +38,14 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.15
+      base >4.11 && <4.16
     , bitvec >1.0 && <2.0
     , bytestring >0.10 && <0.11
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , memory >0.14 && <0.16
-    , template-haskell >2.11 && <2.17
+    , memory >0.14 && <0.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , vector >0.12 && <0.13
   default-language: Haskell2010
@@ -71,7 +71,7 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >4.11 && <4.15
+      base >4.11 && <4.16
     , bitvec >1.0 && <2.0
     , bytestring >0.10 && <0.11
     , cereal >0.5 && <0.6
@@ -81,8 +81,8 @@ test-suite tests
     , hspec-contrib >=0.4.0 && <0.6
     , hspec-discover >=2.4.4 && <2.8
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.16
-    , template-haskell >2.11 && <2.17
+    , memory >0.14 && <0.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , vector >0.12 && <0.13
   default-language: Haskell2010

--- a/packages/scale/scale.cabal
+++ b/packages/scale/scale.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           scale
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       SCALE v2.0 codec for Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/solidity/package.yaml
+++ b/packages/solidity/package.yaml
@@ -1,5 +1,5 @@
 name:                web3-solidity
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Solidity language for Haskell Web3 library.
 description:         This package contains Solidity parsec-based parser and primitive types.
 github:              "airalab/hs-web3"

--- a/packages/solidity/package.yaml
+++ b/packages/solidity/package.yaml
@@ -11,21 +11,21 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - text                 >1.2  && <1.3
-- aeson                >1.2  && <1.6
+- aeson                >1.2  && <2.1
 - cereal               >0.5  && <0.6
-- memory               >0.14 && <0.16
+- memory               >0.14 && <0.17
 - memory-hexstring     >=1.0 && <1.1
 - tagged               >0.8  && <0.9
 - parsec               >3.1  && <3.2
 - basement             >0.0  && <0.1
-- OneTuple             >0.2  && <0.3
+- OneTuple             >0.2  && <0.4
 - microlens            >0.4  && <0.5
 - bytestring           >0.10 && <0.11
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.17
+- template-haskell     >2.11 && <2.18
 - web3-crypto          >=1.0 && <1.1
 
 ghc-options:

--- a/packages/solidity/src/Data/Solidity/Prim/Tuple.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Tuple.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 -- |
 -- Module      :  Data.Solidity.Prim.Tuple
@@ -26,7 +28,9 @@ import           Data.Solidity.Abi           (AbiGet, AbiPut, AbiType (..))
 import           Data.Solidity.Abi.Generic   ()
 import           Data.Solidity.Prim.Tuple.TH (tupleDecs)
 
+#if __GLASGOW_HASKELL__ < 900
 deriving instance GHC.Generic (OneTuple a)
+#endif
 instance Generic (OneTuple a)
 
 instance AbiType a => AbiType (OneTuple a) where

--- a/packages/solidity/src/Language/Solidity/Abi.hs
+++ b/packages/solidity/src/Language/Solidity/Abi.hs
@@ -91,6 +91,11 @@ data StateMutability
   | SMNonPayable
   deriving (Eq, Ord, Show)
 
+$(deriveJSON (defaultOptions {
+    sumEncoding = TaggedObject "stateMutability" "contents"
+  , constructorTagModifier = fmap toLower . drop 2 })
+    ''StateMutability)
+
 -- | Elementary contract interface item
 data Declaration = DConstructor
     { conInputs :: [FunctionArg]
@@ -182,12 +187,6 @@ $(deriveToJSON
        , constructorTagModifier = over _head toLower . drop 1
        , fieldLabelModifier = over _head toLower . drop 3 })
    ''Declaration)
-
-$(deriveJSON (defaultOptions {
-    sumEncoding = TaggedObject "stateMutability" "contents"
-  , constructorTagModifier = fmap toLower . drop 2 })
-    ''StateMutability)
-
 
 -- | Contract Abi is a list of method / event declarations
 newtype ContractAbi = ContractAbi { unAbi :: [Declaration] }

--- a/packages/solidity/web3-solidity.cabal
+++ b/packages/solidity/web3-solidity.cabal
@@ -46,20 +46,20 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      OneTuple >0.2 && <0.3
-    , aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      OneTuple >0.2 && <0.4
+    , aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , basement >0.0 && <0.1
     , bytestring >0.10 && <0.11
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , parsec >3.1 && <3.2
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , web3-crypto ==1.0.*
   default-language: Haskell2010
@@ -94,9 +94,9 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      OneTuple >0.2 && <0.3
-    , aeson >1.2 && <1.6
-    , base >4.11 && <4.15
+      OneTuple >0.2 && <0.4
+    , aeson >1.2 && <2.1
+    , base >4.11 && <4.16
     , basement >0.0 && <0.1
     , bytestring >0.10 && <0.11
     , cereal >0.5 && <0.6
@@ -106,12 +106,12 @@ test-suite tests
     , hspec-contrib >=0.4.0 && <0.6
     , hspec-discover >=2.4.4 && <2.8
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.16
+    , memory >0.14 && <0.17
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , parsec >3.1 && <3.2
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.17
+    , template-haskell >2.11 && <2.18
     , text >1.2 && <1.3
     , web3-crypto ==1.0.*
   default-language: Haskell2010

--- a/packages/solidity/web3-solidity.cabal
+++ b/packages/solidity/web3-solidity.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3-solidity
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Solidity language for Haskell Web3 library.
 description:    This package contains Solidity parsec-based parser and primitive types.
 category:       Network

--- a/packages/web3/package.yaml
+++ b/packages/web3/package.yaml
@@ -1,5 +1,5 @@
 name:                web3
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Haskell Web3 library.
 description:         Client library for Third Generation of Web.
 github:              "airalab/hs-web3"

--- a/packages/web3/package.yaml
+++ b/packages/web3/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.15
+- base                 >4.11 && <4.16
 - web3-provider        >=1.0 && <1.1
 - web3-ethereum        >=1.0 && <1.1
 - web3-polkadot        >=1.0 && <1.1

--- a/packages/web3/web3.cabal
+++ b/packages/web3/web3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           web3
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Haskell Web3 library.
 description:    Client library for Third Generation of Web.
 category:       Network

--- a/packages/web3/web3.cabal
+++ b/packages/web3/web3.cabal
@@ -31,7 +31,7 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.15
+      base >4.11 && <4.16
     , web3-ethereum ==1.0.*
     , web3-polkadot ==1.0.*
     , web3-provider ==1.0.*

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
-resolver: lts-18.23
+resolver: lts-19.21
 
 # User packages to be built.
 packages:
@@ -21,6 +21,8 @@ packages:
 # Extra package dependencies
 extra-deps:
 - animalcase-0.1.0.2@sha256:d7b80c3130c68d7ce8ddd9782588b2c4dd7da86461f302c54cc4acddf0902b51
+- git: https://github.com/iostat/relapse.git
+  commit: 616dccb01c892375d5af52b49463349d2adfebd2
 
 # Dependencies bounds
 pvp-bounds: both


### PR DESCRIPTION
We would like to turn this into a self-contained PR on the upstream library. The idea of this change is to use CPP code to fudge around differences in GHC <9 and >=9. Upper bounds are bumped but no lower bound changes are needed that way.

This particular PR just updates the version numbers to make it quicker to publish to hackage for the upstream maintainer.