### PR TITLE
Add ToJSON instances for IntN, UintN and generated datatypes

### DIFF
--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -15,6 +15,7 @@ dependencies:
 - text                 >1.2  && <1.3
 - vinyl                >0.5  && <0.14
 - aeson                >1.2  && <2.2
+- aeson-casing         >=0.2 && <0.3
 - tagged               >0.8  && <0.9
 - memory               >0.14 && <0.17
 - relapse              >=1.0 && <2.0

--- a/packages/ethereum/web3-ethereum.cabal
+++ b/packages/ethereum/web3-ethereum.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -58,6 +58,7 @@ library
   build-depends:
       OneTuple >0.2 && <0.4
     , aeson >1.2 && <2.2
+    , aeson-casing ==0.2.*
     , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , data-default >0.7 && <0.8
@@ -122,6 +123,7 @@ test-suite tests
   build-depends:
       OneTuple >0.2 && <0.4
     , aeson >1.2 && <2.2
+    , aeson-casing ==0.2.*
     , base >4.11 && <4.16
     , bytestring >0.10 && <0.11
     , data-default >0.7 && <0.8

--- a/packages/solidity/src/Data/Solidity/Prim/Int.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Int.hs
@@ -34,6 +34,7 @@ module Data.Solidity.Prim.Int
 import qualified Basement.Numerical.Number as Basement (toInteger)
 import           Basement.Types.Word256    (Word256 (Word256))
 import qualified Basement.Types.Word256    as Basement (quot, rem)
+import           Data.Aeson                (ToJSON(..))
 import           Data.Bits                 (Bits (testBit), (.&.))
 import           Data.Proxy                (Proxy (..))
 import           Data.Serialize            (Get, Putter, Serialize (get, put))
@@ -90,6 +91,9 @@ instance (n <= 256) => AbiGet (UIntN n) where
 instance (n <= 256) => AbiPut (UIntN n) where
     abiPut = putWord256 . unUIntN
 
+instance (KnownNat n, n <= 256) => ToJSON (UIntN n) where
+  toJSON = toJSON . toInteger
+
 -- | Signed integer with fixed length in bits.
 newtype IntN (n :: Nat) = IntN { unIntN :: Word256 }
     deriving (Eq, Ord, Enum, Bits, Generic)
@@ -129,6 +133,9 @@ instance (n <= 256) => AbiGet (IntN n) where
 
 instance (n <= 256) => AbiPut (IntN n) where
     abiPut = putWord256 . unIntN
+
+instance (KnownNat n, n <= 256) => ToJSON (IntN n) where
+  toJSON = toJSON . toInteger
 
 -- | Serialize 256 bit unsigned integer.
 putWord256 :: Putter Word256


### PR DESCRIPTION
# Motivation

From the `Network.Ethereum.Contract.TH` module we can generate native ADTs to events specified on a contract ABIs. This is great if the rest of you project uses exclusively Haskell, but if you need to play along another languages or ecosystems, having a common representation such a JSON is necessary. This PR adds `ToJSON` instances for all events types (not internal `Data$` nor `Indexed$` ADTs though).

# Changes

- Add missing `ToJSON` instances for `UintN` and `IntN`.
- Add aeson-casing dependency
- Add `ToJSON` instances for generated datatypes using `Generic` deriving (aeson default).

# Known infelicities

The `init'` function I use to recover the input name from the record selector of an ADT is a hack. The correct way should be to obtain that name from the `eveArgName` field on the inputs. But if I follow path, I would have to write custom code for instance generation, losing the benefits of using the `Generic` instance. It is a tradeoff and I choose succinctness. 

# Tests

I have been using this for 1 month, storing the JSONs produced on a postgresql database. So far the output matches what I would expect.

For a event declared like this
``` json
  {
    "anonymous": false,
    "inputs": [
      {
        "indexed": true,
        "internalType": "address",
        "name": "from",
        "type": "address"
      },
      {
        "indexed": true,
        "internalType": "address",
        "name": "to",
        "type": "address"
      },
      {
        "indexed": true,
        "internalType": "uint256",
        "name": "tokenId",
        "type": "uint256"
      }
    ],
    "name": "Transfer",
    "type": "event"
  },
```
We generate the following instance
``` ghci
ghci> toJSON (Transfer def def 1000)
Object (fromList [("from",String "0x0000000000000000000000000000000000000000"),("to",String "0x0000000000000000000000000000000000000000"),("tokenId",Number 1000.0)])
```

On anohter event with arguments prefixed by _
``` json
  {
    "anonymous": false,
    "inputs": [
      {
        "indexed": true,
        "name": "_bidder",
        "type": "address"
      },
      {
        "indexed": true,
        "name": "_editionNumber",
        "type": "uint256"
      },
      {
        "indexed": true,
        "name": "_tokenId",
        "type": "uint256"
      },
      {
        "indexed": false,
        "name": "_amount",
        "type": "uint256"
      }
    ],
    "name": "BidAccepted",
    "type": "event"
  },
```
The json instance is
``` ghci
ghci> toJSON (BidAccepted def 100 100 150)
Object (fromList [("_amount",Number 150.0),("_bidder",String "0x0000000000000000000000000000000000000000"),("_editionNumber",Number 100.0),("_tokenId",Number 100.0)])
```

# License

Copyright belongs to SuperRare Labs. It is licensed under the Apache 2.0 terms as the rest of this project. If another license is needed with more liberal terms we can accommodate that. Thank you for all your work on this library!