### PR TITLE
Fix ABI encoding for fixed length lists

### DIFF
--- a/packages/solidity/src/Data/Solidity/Prim/List.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/List.hs
@@ -71,7 +71,7 @@ instance (AbiPut a, KnownNat n, 1 <= n+1) => AbiPut (ListN n a) where
     abiPut l = if isDynamic (Proxy :: Proxy a) then do
                    let encs = SL.map (runPut . abiPut) l
                        lengths = SL.map ((fromIntegral :: Int -> Word256) . B.length) encs
-                       len = fromInteger (natVal (Proxy :: Proxy n))
+                       len = natVal (Proxy :: Proxy n)
                        offsets = SL.init $ SL.scanl' (+) (fromIntegral (0x20 * len)) lengths
                    SL.mapM_ putWord256 offsets
                    SL.mapM_ putByteString encs

--- a/packages/solidity/src/Data/Solidity/Prim/List.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/List.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
 
 -- |
 -- Module      :  Data.Solidity.Prim.List
@@ -23,16 +25,16 @@ module Data.Solidity.Prim.List
 
 import           Basement.Nat           (NatWithinBound)
 import           Basement.Sized.List    (ListN, toListN_, unListN)
-import qualified Basement.Sized.List    as SL (mapM_, replicateM)
+import qualified Basement.Sized.List    as SL (init, map, mapM, mapM_, replicateM, scanl')
 import           Basement.Types.Word256 (Word256)
-import           Control.Monad          (replicateM, mapM_, forM)
+import           Control.Monad          (replicateM, forM)
 import qualified Data.ByteString        as B
-import           Data.List              (init, scanl')
+import           Data.List              (scanl')
 import           Data.Proxy             (Proxy (..))
 import           Data.Serialize.Put     (runPut, putByteString)
 import           Data.Serialize.Get     (skip, lookAhead)
 import           GHC.Exts               (IsList (..))
-import           GHC.TypeLits           (KnownNat)
+import           GHC.TypeLits           (KnownNat, natVal, type (+), type (<=))
 
 import           Data.Solidity.Abi      (AbiGet (..), AbiPut (..), AbiType (..))
 import           Data.Solidity.Prim.Int (getWord256, putWord256)
@@ -62,14 +64,30 @@ instance AbiGet a => AbiGet [a] where
                   else
                     replicateM len abiGet
 
-instance AbiType (ListN n a) where
-    isDynamic _ = False
+instance (AbiType a, KnownNat n) => AbiType (ListN n a) where
+    isDynamic _ = natVal (Proxy :: Proxy n) > 0 && isDynamic (Proxy :: Proxy a)
 
-instance AbiPut a => AbiPut (ListN n a) where
-    abiPut = SL.mapM_ abiPut
+instance (AbiPut a, KnownNat n, 1 <= n+1) => AbiPut (ListN n a) where
+    abiPut l = if isDynamic (Proxy :: Proxy a) then do
+                   let encs = SL.map (runPut . abiPut) l
+                       lengths = SL.map ((fromIntegral :: Int -> Word256) . B.length) encs
+                       len = fromInteger (natVal (Proxy :: Proxy n))
+                       offsets = SL.init $ SL.scanl' (+) (fromIntegral (0x20 * len)) lengths
+                   SL.mapM_ putWord256 offsets
+                   SL.mapM_ putByteString encs
+               else
+                   SL.mapM_ abiPut l
 
 instance (NatWithinBound Int n, KnownNat n, AbiGet a) => AbiGet (ListN n a) where
-    abiGet = SL.replicateM abiGet
+    abiGet = do let len = fromInteger (natVal (Proxy :: Proxy n))
+                if isDynamic (Proxy :: Proxy a) then do
+                    offsets <- SL.replicateM getWord256
+                    let currentOffset = 0x20 * len
+                    flip SL.mapM offsets $ \dataOffset -> lookAhead $ do
+                        skip (fromIntegral dataOffset - currentOffset)
+                        abiGet
+                  else
+                    SL.replicateM abiGet
 
 instance (NatWithinBound Int n, KnownNat n) => IsList (ListN n a) where
     type Item (ListN n a) = a


### PR DESCRIPTION
The ABI encoding for fixed length Solidity arrays `T[k]` was wrong in the case that `T` is dynamic. If T is dynamic, then according to the [spec](https://docs.soliditylang.org/en/v0.5.3/abi-spec.html#formal-specification-of-the-encoding),

> The following types are called “dynamic”:
> `T[k]` for any dynamic `T` and any `k >= 0`

This PR ensures this is the case and handles encoding for dynamic `T` similar to how it is handled in the variable length array case for `T[]` which was fixed in #126.