### PR TITLE
add cpp for OneTuple > 0.3

### DIFF
--- a/packages/solidity/src/Data/Solidity/Prim/Tuple.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Tuple.hs
@@ -20,7 +20,11 @@
 module Data.Solidity.Prim.Tuple where
 
 import           Data.Proxy                  (Proxy (..))
+#if MIN_VERSION_OneTuple(0,3,0)
+import           Data.Tuple.Solo             (Solo (..))
+#else
 import           Data.Tuple.OneTuple         (OneTuple (..))
+#endif
 import           Generics.SOP                (Generic)
 import qualified GHC.Generics                as GHC (Generic)
 
@@ -28,6 +32,14 @@ import           Data.Solidity.Abi           (AbiGet, AbiPut, AbiType (..))
 import           Data.Solidity.Abi.Generic   ()
 import           Data.Solidity.Prim.Tuple.TH (tupleDecs)
 
+#if MIN_VERSION_OneTuple(0,3,0)
+instance Generic (Solo a)
+instance AbiType a => AbiType (Solo a) where
+    isDynamic _ = isDynamic (Proxy :: Proxy a)
+
+instance AbiGet a => AbiGet (Solo a)
+instance AbiPut a => AbiPut (Solo a)
+#else
 #if MIN_VERSION_base(4,15,0)
 #else
 deriving instance GHC.Generic (OneTuple a)
@@ -39,5 +51,5 @@ instance AbiType a => AbiType (OneTuple a) where
 
 instance AbiGet a => AbiGet (OneTuple a)
 instance AbiPut a => AbiPut (OneTuple a)
-
+#endif
 $(concat <$> mapM tupleDecs [2..20])


### PR DESCRIPTION
OneTuple becomes a pattern synonym for `Solo` above version 0.3.  This fixes the error that arises from deriving generic on the synonym.