### PR TITLE
Add `eth_feeHistory` method to Eth API

### DIFF
--- a/packages/ethereum/src/Network/Ethereum/Api/Eth.hs
+++ b/packages/ethereum/src/Network/Ethereum/Api/Eth.hs
@@ -18,11 +18,19 @@ module Network.Ethereum.Api.Eth where
 import           Data.ByteArray.HexString   (HexString)
 import           Data.Solidity.Prim.Address (Address)
 import           Data.Text                  (Text)
-import           Network.Ethereum.Api.Types (Block, BlockT, Call, Change,
-                                             DefaultBlock, Filter, Quantity,
-                                             SyncingState, Transaction,
-                                             TxReceipt)
-import           Network.JsonRpc.TinyClient (JsonRpc (..))
+import           Network.Ethereum.Api.Types
+    ( Block
+    , BlockT
+    , Call
+    , Change
+    , DefaultBlock
+    , Filter
+    , Quantity
+    , SyncingState
+    , Transaction
+    , TxReceipt
+    )
+import           Network.JsonRpc.TinyClient (JsonRpc(..))
 
 -- | Returns the current ethereum protocol version.
 protocolVersion :: JsonRpc m => m Text
@@ -145,6 +153,10 @@ call = remote "eth_call"
 estimateGas :: JsonRpc m => Call -> m Quantity
 {-# INLINE estimateGas #-}
 estimateGas = remote "eth_estimateGas"
+
+-- | Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.
+feeHistory :: (JsonRpc m) => Quantity -> DefaultBlock -> [Double] -> m FeeHistory
+feeHistory = remote "eth_feeHistory"
 
 -- | Returns information about a block by hash with only hashes of the transactions in it.
 getBlockByHashLite :: JsonRpc m => HexString -> m (Maybe (BlockT HexString))

--- a/packages/ethereum/src/Network/Ethereum/Api/Types.hs
+++ b/packages/ethereum/src/Network/Ethereum/Api/Types.hs
@@ -300,3 +300,23 @@ data BlockT tx = Block
 
 $(deriveJSON (defaultOptions
     { fieldLabelModifier = over _head toLower . drop 5 }) ''BlockT)
+
+--| Fee History information
+data FeeHistory
+  = FeeHistory
+  { feeHistoryBaseFeePerBlobGas :: [Quantity]
+  -- ^ array of block base fees per blob gas.
+  , feeHistoryBaseFeePerGas :: [Quantity]
+  -- ^ Array of block base fees per gas.
+  , feeHistoryBlobGasUsedRatio :: [Rational]
+  -- ^ Array of block base fees per blob gas.
+  , feeHistoryGasUsedRatio :: [Rational]
+  -- ^ Array of block gas used ratios.
+  , feeHistoryOldestBlock :: Quantity
+  -- ^ QUANTITY - lowest number block of returned range.
+  , feeHistoryReward :: [[Quantity]]
+  -- ^ Two-dimensional array of effective priority fees per gas at the requested block percentiles.
+  }
+  deriving (Generic, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = over _head toLower . drop 10} ''FeeHistory)


### PR DESCRIPTION

It is defined in the [ethereum spec](https://github.com/ethereum/execution-apis/blob/f910189261255eb0ebc49ee0e6f10f48562a41c3/src/eth/fee_market.yaml#L43)

Additionally, I ran stylish-haskell in the files using the provided configuration. It turns out it changed little bit the formatting